### PR TITLE
Ensure that result is table in parseHints

### DIFF
--- a/lua/rust-tools/inlay_hints.lua
+++ b/lua/rust-tools/inlay_hints.lua
@@ -52,6 +52,9 @@ local namespace = vim.api.nvim_create_namespace("rust-analyzer/inlayHints")
 local function parseHints(result)
     local map = {}
 
+    if type(result) ~= 'table' then
+        return {}
+    end
     for _, value in pairs(result) do
         local line = tostring(value.range["end"].line)
         local label = value.label


### PR DESCRIPTION
Thanks for this nice plugin! I've found a small issue to you could maybe investigate.

I'm using the latest master of rust-analyzer (built yesterday). When I open a rust file in the moment rust-analyzer starts up (like right after file open) it will return the numeric value `0` as a result of `rust-analyzer/inlayHints`. After some start-up time, indexing time it will return the expected table.

This fix would work for me. Maybe you could have a look whether there's a better solution.