### PR TITLE
Add config option to change the color of inlay hints

### DIFF
--- a/lua/rust-tools/config.lua
+++ b/lua/rust-tools/config.lua
@@ -49,7 +49,10 @@ local defaults = {
             right_align = false,
 
             -- padding from the right if right_align is true
-            right_align_padding = 7
+            right_align_padding = 7,
+
+            -- The color of the hints
+            highlight = "Comment"
         },
 
         hover_actions = {

--- a/lua/rust-tools/inlay_hints.lua
+++ b/lua/rust-tools/inlay_hints.lua
@@ -155,7 +155,7 @@ local function get_handler()
             vim.api.nvim_buf_set_extmark(bufnr, namespace, line, 0, {
                 virt_text_pos = config.options.tools.inlay_hints.right_align and
                     "right_align" or "eol",
-                virt_text = {{virt_text, "Comment"}}
+                virt_text = {{virt_text, config.options.tools.inlay_hints.highlight}}
             });
 
             -- update state


### PR DESCRIPTION
Using the same color as the comments can be confusing a bit, the ability to change the color would be a nice addition.