### PR TITLE
make runnables work on paths with spaces

### DIFF
--- a/lua/rust-tools/runnables.lua
+++ b/lua/rust-tools/runnables.lua
@@ -33,7 +33,7 @@ local function getCommand(c, results)
 
     local dir = args.workspaceRoot;
 
-    ret = string.format("cd %s && cargo ", dir)
+    ret = string.format("cd '%s' && cargo ", dir)
 
     for _, value in ipairs(args.cargoArgs) do
         ret = ret .. value .. " "


### PR DESCRIPTION
One of my projects had a space in the path name, which caused `runnables` to fail.