### PR TITLE
Fix run_command calls

### DIFF
--- a/lua/rust-tools/runnables.lua
+++ b/lua/rust-tools/runnables.lua
@@ -92,7 +92,7 @@ local function handler(_, _, result, _, _, _)
     -- get the choice from the user
     local choice = vim.fn.inputlist(getOptions(result, true, true))
 
-    run_command(choice, result)
+    M.run_command(choice, result)
 end
 
 local function get_telescope_handler(opts)
@@ -110,7 +110,7 @@ local function get_telescope_handler(opts)
                 local choice = action_state.get_selected_entry().index
 
                 actions.close(bufnr)
-                run_command(choice, results)
+                M.run_command(choice, results)
             end
 
             map('n', '<CR>', on_select)


### PR DESCRIPTION
Update run_command calls in handler and get_telescope_handler functions to reflect change from run_command to M.run_command.