### PR TITLE
Add hoverRange capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ RustOpenCargo
 RustParentModule
 RustJoinLines
 RustHoverActions
+RustHoverRange 
 RustMoveItemDown
 RustMoveItemUp
 RustStartStandaloneServerForBuffer 
@@ -223,6 +224,14 @@ Note: To activate hover actions, run the command twice (or your hover keymap if 
 -- Command:
 -- RustHoverActions 
 require'rust-tools.hover_actions'.hover_actions()
+```
+
+### Hover Range
+Note: Requires rust-analyzer version after 2021-08-02. Shows the type in visual mode when hovering.
+```lua
+-- Command:
+-- RustHoverRange 
+require'rust-tools.hover_range'.hover_range()
 ```
 
 ### Open Cargo.toml

--- a/lua/rust-tools.lua
+++ b/lua/rust-tools.lua
@@ -37,6 +37,7 @@ local function setupCommands()
             end
         },
         RustHoverActions = {require('rust-tools.hover_actions').hover_actions},
+        RustHoverRange = {require('rust-tools.hover_range').hover_range},
         RustMoveItemDown = {
             function() require('rust-tools.move_item').move_item() end
         },
@@ -73,7 +74,7 @@ local function setup_capabilities()
     capabilities.textDocument.completion.completionItem.snippetSupport = true
 
     -- send actions with hover request
-    capabilities.experimental = {hoverActions = true}
+    capabilities.experimental = {hoverActions = true, hoverRange = true}
 
     -- enable auto-import
     capabilities.textDocument.completion.completionItem.resolveSupport =

--- a/lua/rust-tools/hover_range.lua
+++ b/lua/rust-tools/hover_range.lua
@@ -1,0 +1,27 @@
+local M = {}
+
+local function get_opts()
+    local params = vim.lsp.util.make_range_params()
+    -- set start and end of selection
+    local start_m = vim.api.nvim_buf_get_mark(0, "<")
+    local end_m = vim.api.nvim_buf_get_mark(0, ">")
+    params.range.start = {
+        character = start_m[2],
+        line = start_m[1]-1, -- vim starts counting at 1, but lsp at 0
+    }
+    params.range["end"] = {
+        character = end_m[2],
+        line = end_m[1]-1, -- vim starts counting at 1, but lsp at 0
+    }
+    params.position = params.range
+    params.range = nil
+    --print(vim.inspect(params))
+    
+    return params
+end
+
+function M.hover_range()
+    vim.lsp.buf_request(0, "textDocument/hover", get_opts())
+end
+
+return M


### PR DESCRIPTION
Hi,

The latest release of rust-analyzer added the ability to view the type of selected code in visual mode while hovering.

I really wanted that to be enabled in neovim and hacked something together :smile: .

I added a new command `RustHoverRange` and an experimental capability which will do the work of making the request. It uses the default hover handler for better integration with the hover actions.

I added the new command to the documentation, but did not make a gif of how it works (didn't know how :cry: )

Here some extra links:
* [PR hoverRange in rust-analyzer with example gif](https://github.com/rust-analyzer/rust-analyzer/pull/9693)
* [Specification of the protocol in rust-analyzer](https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/dev/lsp-extensions.md#hover-range)

Hope you like it! :+1: 