### PR TITLE
add noremap=true

### DIFF
--- a/lua/rust-tools/hover_actions.lua
+++ b/lua/rust-tools/hover_actions.lua
@@ -9,6 +9,7 @@ local M = {}
 local function get_params() return vim.lsp.util.make_position_params() end
 
 M._state = {winnr = nil, commands = nil}
+local set_keymap_opt = {noremap = true}
 
 -- run the command under the cursor, if the thing under the cursor is not the
 -- command then do nothing
@@ -89,7 +90,7 @@ function M.handler(_, _, result, _, _, _)
     M._state.winnr = winnr
     vim.api.nvim_buf_set_keymap(bufnr, "n", "<Esc>",
                                 ":lua require'rust-tools.hover_actions'._close_hover()<CR>",
-                                {})
+                                set_keymap_opt)
 
     vim.api.nvim_buf_attach(bufnr, false,
                             {on_detach = function() M._state.winnr = nil end})
@@ -133,11 +134,11 @@ function M.handler(_, _, result, _, _, _)
     -- run the command under the cursor
     vim.api.nvim_buf_set_keymap(bufnr, "n", "<CR>",
                                 ":lua require'rust-tools.hover_actions'._run_command()<CR>",
-                                {})
+                                set_keymap_opt)
     -- close on escape
     vim.api.nvim_buf_set_keymap(bufnr, "n", "<Esc>",
                                 ":lua require'rust-tools.hover_actions'._close_hover()<CR>",
-                                {})
+                                set_keymap_opt)
 end
 
 -- Sends the request to rust-analyzer to get hover actions and handle it

--- a/lua/rust-tools/runnables.lua
+++ b/lua/rust-tools/runnables.lua
@@ -66,7 +66,7 @@ function M.run_command(choice, result)
     utils.resize(false, "-5")
 
     -- close the buffer when escape is pressed :)
-    vim.api.nvim_buf_set_keymap(latest_buf_id, "n", "<Esc>", ":q<CR>", {})
+    vim.api.nvim_buf_set_keymap(latest_buf_id, "n", "<Esc>", ":q<CR>", {noremap=true})
 
     local command = getCommand(choice, result)
 


### PR DESCRIPTION
some people will remap ':' to ';' and vice verse (or other similar bindings), in such case runnable would not be able to run.