### PR TITLE
add inlay_hints.highlight option to README doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,10 @@ local opts = {
             right_align = false,
 
             -- padding from the right if right_align is true
-            right_align_padding = 7
+            right_align_padding = 7,
+
+            -- The color of the hints
+            highlight = "Comment",
         },
 
         hover_actions = {


### PR DESCRIPTION
Easier for new users to know how to configure the color of inlay_hints (e.g. set it to be different from `Comment`)