### PR TITLE
Add ViewCrateGraph ability

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,20 +180,6 @@ local opts = {
             -- crates
             -- default: true
             full = true,
-
-            -- List of backends found on: https://graphviz.org/docs/outputs/
-            -- Is used for input validation and autocompletion
-            -- Last updated: 2021-08-26
-            enabled_graphviz_backends = {
-                "bmp", "cgimage", "canon", "dot", "gv", "xdot", "xdot1.2", "xdot1.4",
-                "eps", "exr", "fig", "gd", "gd2", "gif", "gtk", "ico", "cmap", "ismap",
-                "imap", "cmapx", "imap_np", "cmapx_np", "jpg", "jpeg", "jpe", "jp2",
-                "json", "json0", "dot_json", "xdot_json", "pdf", "pic", "pct", "pict",
-                "plain", "plain-ext", "png", "pov", "ps", "ps2", "psd", "sgi", "svg",
-                "svgz", "tga", "tiff", "tif", "tk", "vml", "vmlz", "wbmp", "webp", "xlib",
-                "x11"
-            }
-
         }
     },
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This plugin adds extra functionality over rust analyzer.
 - `neovim 0.5+`
 - `nvim-lspconfig`
 - `rust-analyzer`
+- `dot` from `graphviz` (only for crate graph)
 
 ## Installation
 
@@ -54,6 +55,7 @@ RustMoveItemDown
 RustMoveItemUp
 RustStartStandaloneServerForBuffer 
 RustDebuggables
+RustViewCrateGraph
 ```
 
 ## Standalone File Support
@@ -161,6 +163,37 @@ local opts = {
 
             -- whether the hover action window gets automatically focused
             auto_focus = false
+        },
+
+        -- settings for showing the crate graph based on graphviz and the dot
+        -- command
+        crate_graph = {
+            -- Backend used for displaying the graph
+            -- see: https://graphviz.org/docs/outputs/
+            -- default: x11
+            backend = "x11",
+            -- where to store the output, nil for no output stored (relative
+            -- path from pwd)
+            -- default: nil
+            output = nil,
+            -- true for all crates.io and external crates, false only the local
+            -- crates
+            -- default: true
+            full = true,
+
+            -- List of backends found on: https://graphviz.org/docs/outputs/
+            -- Is used for input validation and autocompletion
+            -- Last updated: 2021-08-26
+            enabled_graphviz_backends = {
+                "bmp", "cgimage", "canon", "dot", "gv", "xdot", "xdot1.2", "xdot1.4",
+                "eps", "exr", "fig", "gd", "gd2", "gif", "gtk", "ico", "cmap", "ismap",
+                "imap", "cmapx", "imap_np", "cmapx_np", "jpg", "jpeg", "jpe", "jp2",
+                "json", "json0", "dot_json", "xdot_json", "pdf", "pic", "pct", "pict",
+                "plain", "plain-ext", "png", "pov", "ps", "ps2", "psd", "sgi", "svg",
+                "svgz", "tga", "tiff", "tif", "tk", "vml", "vmlz", "wbmp", "webp", "xlib",
+                "x11"
+            }
+
         }
     },
 
@@ -259,6 +292,13 @@ require'rust-tools.parent_module'.parent_module()
 -- Command:
 -- RustJoinLines  
 require'rust-tools.join_lines'.join_lines()
+```
+
+### View crate graph
+```lua
+-- Command:
+-- RustViewCrateGraph [backend [output]]
+require'rust-tools.crate_graph'.view_crate_graph(backend, output)
 ```
 
 ## Inspiration

--- a/lua/rust-tools.lua
+++ b/lua/rust-tools.lua
@@ -45,6 +45,13 @@ local function setupCommands()
             function()
                 require('rust-tools.move_item').move_item(true)
             end
+        },
+        RustViewCrateGraph = {
+            function(backend, output)
+                require('rust-tools.crate_graph').view_crate_graph(backend, output)
+            end,
+            "-nargs=* -complete=customlist,v:lua.rust_tools_get_graphviz_backends",
+            description = '`:RustViewCrateGraph [<backend> [<output>]]` Show the crate graph'
         }
     })
 end

--- a/lua/rust-tools/config.lua
+++ b/lua/rust-tools/config.lua
@@ -94,11 +94,21 @@ local defaults = {
             auto_focus = false
         },
 
+        -- settings for showing the crate graph based on graphviz and the dot
+        -- command
         crate_graph = {
             -- Backend used for displaying the graph
-            backend = "x11", -- see: https://graphviz.org/docs/outputs/
-            output = nil, -- where to store the output, nil for no output stored (relative path from cwd)
-            full = true, -- true for all crates.io and external crates, false only the local crates
+            -- see: https://graphviz.org/docs/outputs/
+            -- default: x11
+            backend = "x11",
+            -- where to store the output, nil for no output stored (relative
+            -- path from pwd)
+            -- default: nil
+            output = nil,
+            -- true for all crates.io and external crates, false only the local
+            -- crates
+            -- default: true
+            full = true,
 
             -- List of backends found on: https://graphviz.org/docs/outputs/
             -- Is used for input validation and autocompletion

--- a/lua/rust-tools/config.lua
+++ b/lua/rust-tools/config.lua
@@ -2,6 +2,11 @@ local vim = vim
 
 local M = {}
 
+-- Needed for autocompletion to work
+_G.rust_tools_get_graphviz_backends = function()
+    return M.options.tools.crate_graph.enabled_graphviz_backends
+end
+
 local defaults = {
     tools = { -- rust-tools options
         -- automatically set inlay hints (type hints)
@@ -87,6 +92,27 @@ local defaults = {
             -- whether the hover action window gets automatically focused
             -- default: false
             auto_focus = false
+        },
+
+        crate_graph = {
+            -- Backend used for displaying the graph
+            backend = "x11", -- see: https://graphviz.org/docs/outputs/
+            output = nil, -- where to store the output, nil for no output stored (relative path from cwd)
+            full = true, -- true for all crates.io and external crates, false only the local crates
+
+            -- List of backends found on: https://graphviz.org/docs/outputs/
+            -- Is used for input validation and autocompletion
+            -- Last updated: 2021-08-26
+            enabled_graphviz_backends = {
+                "bmp", "cgimage", "canon", "dot", "gv", "xdot", "xdot1.2", "xdot1.4",
+                "eps", "exr", "fig", "gd", "gd2", "gif", "gtk", "ico", "cmap", "ismap",
+                "imap", "cmapx", "imap_np", "cmapx_np", "jpg", "jpeg", "jpe", "jp2",
+                "json", "json0", "dot_json", "xdot_json", "pdf", "pic", "pct", "pict",
+                "plain", "plain-ext", "png", "pov", "ps", "ps2", "psd", "sgi", "svg",
+                "svgz", "tga", "tiff", "tif", "tk", "vml", "vmlz", "wbmp", "webp", "xlib",
+                "x11"
+            }
+
         }
     },
 

--- a/lua/rust-tools/crate_graph.lua
+++ b/lua/rust-tools/crate_graph.lua
@@ -39,6 +39,11 @@ local function handler_factory(backend, output)
         -- Needs to be handled with care to prevent security problems
         local handle = io.popen(cmd, "w")
         handle:write(graph)
+
+        -- needs to be here otherwise dot may take a long time before it gets
+        -- any input + cleaning up (not waiting for garbage collection)
+        handle:flush()
+        handle:close()
     end
 end
 

--- a/lua/rust-tools/crate_graph.lua
+++ b/lua/rust-tools/crate_graph.lua
@@ -1,0 +1,49 @@
+local utils = require('rust-tools.utils.utils')
+local config = require('rust-tools.config')
+
+local M = {}
+
+local function get_opts()
+    return {full = config.options.tools.crate_graph.full}
+end
+
+-- Creation of the correct handler depending on the initial call of the command
+-- and give the option to override global settings
+local function handler_factory(backend, output)
+    backend = backend or config.options.tools.crate_graph.backend
+    output = output or config.options.tools.crate_graph.output
+
+    -- Graph is a representation of the crate graph following the graphviz format
+    -- The handler processes and pipes the graph to the dot command that will
+    -- visualize with the given backend
+    return function(err, _, graph, _, _)
+        if err ~= nil then
+            error("Cound not execute request to server"..err)
+            return
+        end
+
+        -- Validating backend
+        if not utils.contains(config.options.tools.crate_graph.enabled_graphviz_backends, backend) then
+            error("Backend not recognized as valid")
+        end
+
+        graph = string.gsub(graph, "\n", "")
+        print("rust-tools: Processing crate graph. This may take a while...")
+
+        local cmd = "dot -T"..backend
+        if output ~= nil then -- optionaly pipe to output
+            cmd = cmd.." > "..output
+        end
+
+        -- Execute dot command to generate the output graph
+        -- Needs to be handled with care to prevent security problems
+        local handle = io.popen(cmd, "w")
+        handle:write(graph)
+    end
+end
+
+function M.view_crate_graph(backend, output)
+    vim.lsp.buf_request(0, "rust-analyzer/viewCrateGraph", get_opts(), handler_factory(backend, output))
+end
+
+return M

--- a/lua/rust-tools/utils/utils.lua
+++ b/lua/rust-tools/utils/utils.lua
@@ -33,4 +33,13 @@ function M.is_bufnr_rust(bufnr)
     return vim.api.nvim_buf_get_option(bufnr, 'ft') == 'rust'
 end
 
+function M.contains(list, item)
+    for _, val in ipairs(list) do
+        if item == val then
+            return true
+        end
+    end
+    return false
+end
+
 return M


### PR DESCRIPTION
Hi @simrat39 ,

I implemented the view crate graph-feature. It is based around `rust-analyzer/viewCrateGraph` method and pipes the result to the `dot`-command from graphviz to show the graph.

I added the option to chose the backend and file output in the global config and optionally in the command `:RustViewCrateGraph` (more info in the `README.md`).

This introduces a new requirement for the `dot`-command in a posix-shell, but I tried to make it so that only when using this new feature an error might occur.

To enable auto completion and better sanitazation of the command arguments, I added a list of all the current backends in `graphviz` (`config.lua` and `README.md`) and used it in `rust-tools.lua` and `crate_graph.lua`. This list is hardcoded and may need to be changed when graphviz updates. To prevent users of the plugin from not being able to use the possible new backends, I added the list as a setting in the config instead of placing it all in `crate_graph.lua`. But I am not sure if placing it in the readme as I have done now, is the best sollution from a user/UX standpoint since this *might* introduce some confusion for people unfamiliar with `graphviz`. So I was thinking to remove the backendslist from the readme, but leave it in the `config.lua` file. What do you think?

I hope you like this feature as much as I do :smile: 

Kind regards,
@SamClercky 

Ps. Some interesting links:
- [rust-analyzer method](https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/dev/lsp-extensions.md#view-crate-graph)
- [Graphviz homepage](https://graphviz.org/)
- [Graphviz backends](https://graphviz.org/docs/outputs/)
- [Graphviz dot command](https://graphviz.org/doc/info/command.html)