### PR TITLE
Update handler signatures

### DIFF
--- a/lua/rust-tools/debuggables.lua
+++ b/lua/rust-tools/debuggables.lua
@@ -67,7 +67,14 @@ local function sanitize_results_for_debugging(result)
     return ret
 end
 
-local function handler(_, _, result)
+local function handler(...)
+    local _args = { ... }
+    local result
+    if vim.fn.has 'nvim-0.5.1' == 1 then
+        result = _args[2]
+    else
+        result = _args[3]
+    end
     result = sanitize_results_for_debugging(result)
 
     -- get the choice from the user

--- a/lua/rust-tools/hover_actions.lua
+++ b/lua/rust-tools/hover_actions.lua
@@ -71,7 +71,15 @@ local function parse_commands()
     return prompt
 end
 
-function M.handler(_, _, result, _, _, _)
+function M.handler(...)
+    local _args = { ... }
+    local result
+    if vim.fn.has 'nvim-0.5.1' == 1 then
+        result = _args[2]
+    else
+        result = _args[3]
+    end
+
     if not (result and result.contents) then
         -- return { 'No information available' }
         return

--- a/lua/rust-tools/inlay_hints.lua
+++ b/lua/rust-tools/inlay_hints.lua
@@ -90,7 +90,16 @@ end
 local function get_handler()
     local opts = config.options.tools.inlay_hints
 
-    return function(_, _, result, _, bufnr, _)
+    return function(...)
+        local _args = { ... }
+        local result, bufnr
+        if vim.fn.has 'nvim-0.5.1' == 1 then
+            result = _args[2]
+            bufnr = _args[3].bufnr
+        else
+            result = _args[3]
+            bufnr = _args[5]
+        end
         if (vim.api.nvim_get_current_buf() ~= bufnr) then return end
 
         -- clean it up at first

--- a/lua/rust-tools/join_lines.lua
+++ b/lua/rust-tools/join_lines.lua
@@ -4,23 +4,32 @@ local vim = vim
 local M = {}
 
 local function get_params()
-    local params = vim.lsp.util.make_range_params()
-    local range = params.range
+	local params = vim.lsp.util.make_range_params()
+	local range = params.range
 
-    params.range = nil
-    params.ranges = {range}
+	params.range = nil
+	params.ranges = { range }
 
-    return params
+	return params
 end
 
-local function handler(_, _, result, _, bufnr, _)
-    vim.lsp.util.apply_text_edits(result, bufnr)
+local function handler(...)
+	local _args = { ... }
+	local result, bufnr
+	if vim.fn.has "nvim-0.5.1" == 1 then
+		result = _args[2]
+		bufnr = _args[3].bufnr
+	else
+		result = _args[3]
+		bufnr = _args[5]
+	end
+	vim.lsp.util.apply_text_edits(result, bufnr)
 end
 
 -- Sends the request to rust-analyzer to get the TextEdits to join the lines
 -- under the cursor and applies them
 function M.join_lines()
-    vim.lsp.buf_request(0, "experimental/joinLines", get_params(), handler)
+	vim.lsp.buf_request(0, "experimental/joinLines", get_params(), handler)
 end
 
 return M

--- a/lua/rust-tools/move_item.lua
+++ b/lua/rust-tools/move_item.lua
@@ -13,7 +13,14 @@ local function get_params(up)
 end
 
 -- move it baby
-local function handler(_, _, result, _, _, _)
+local function handler(...)
+    local _args = { ... }
+    local result
+    if vim.fn.has 'nvim-0.5.1' == 1 then
+        result = _args[2]
+    else
+        result = _args[3]
+    end
     if result == nil then return end
     utils.snippet_text_edits_to_text_edits(result)
     vim.lsp.util.apply_text_edits(result)

--- a/lua/rust-tools/open_cargo_toml.lua
+++ b/lua/rust-tools/open_cargo_toml.lua
@@ -9,7 +9,14 @@ local function get_params()
     }
 end
 
-local function handler(_, _, result, _, _, _)
+local function handler(...)
+    local _args = { ... }
+    local result
+    if vim.fn.has 'nvim-0.5.1' == 1 then
+        result = _args[2]
+    else
+        result = _args[3]
+    end
     vim.lsp.util.jump_to_location(result)
 end
 

--- a/lua/rust-tools/parent_module.lua
+++ b/lua/rust-tools/parent_module.lua
@@ -7,7 +7,14 @@ local function get_params()
     return vim.lsp.util.make_position_params();
 end
 
-local function handler(_, _, result, _, _, _)
+local function handler(...)
+    local _args = { ... }
+    local result
+    if vim.fn.has 'nvim-0.5.1' == 1 then
+        result = _args[2]
+    else
+        result = _args[3]
+    end
     if result == nil or vim.tbl_isempty(result) then
        vim.api.nvim_out_write("Can't find parent module\n")
        return;

--- a/lua/rust-tools/runnables.lua
+++ b/lua/rust-tools/runnables.lua
@@ -79,7 +79,14 @@ function M.run_command(choice, result)
     vim.api.nvim_buf_attach(latest_buf_id, false, {on_detach = onDetach})
 end
 
-local function handler(_, _, result, _, _, _)
+local function handler(...)
+    local _args = { ... }
+    local result
+    if vim.fn.has 'nvim-0.5.1' == 1 then
+        result = _args[2]
+    else
+        result = _args[3]
+    end
     -- get the choice from the user
     local choice = vim.fn.inputlist(getOptions(result, true, true))
 

--- a/lua/rust-tools/server_status.lua
+++ b/lua/rust-tools/server_status.lua
@@ -3,7 +3,14 @@ local inlay = require('rust-tools.inlay_hints')
 
 local M = {}
 
-function M.handler(_, _, result)
+function M.handler(...)
+    local _args = { ... }
+    local result
+    if vim.fn.has 'nvim-0.5.1' == 1 then
+        result = _args[2]
+    else
+        result = _args[3]
+    end
     if result.quiescent and config.options.tools.autoSetHints then
        inlay.set_inlay_hints();
     end


### PR DESCRIPTION
The old handler signature is incompatible with the one neovim expects, so all handlers set
by this plugin will fail. With this PR, the correct signature is used for handlers, thus
they can be used again in the latest nightly.

Fixes #61
