### PR TITLE
don't echo commands in mappings

### DIFF
--- a/lua/rust-tools/hover_actions.lua
+++ b/lua/rust-tools/hover_actions.lua
@@ -8,7 +8,7 @@ local M = {}
 local function get_params() return vim.lsp.util.make_position_params() end
 
 M._state = {winnr = nil, commands = nil}
-local set_keymap_opt = {noremap = true}
+local set_keymap_opt = {noremap = true, silent = true}
 
 -- run the command under the cursor, if the thing under the cursor is not the
 -- command then do nothing


### PR DESCRIPTION
I noticed whenever I close the popup window with escape, `:lua require'rust-tools.hover_actions'._close_hover()<CR>` gets printed to the status line – given that function isn't documented and it starts with an underscore, I guess it's meant to be internal and shouldn't be exposed to the user, and anyway it's not very useful to see that every time I close the popup.

Making the mappings `<silent>` stops the command being echoed to the status line.