### PR TITLE
Fix highlight mode for inlay hints

### DIFF
--- a/lua/rust-tools/inlay_hints.lua
+++ b/lua/rust-tools/inlay_hints.lua
@@ -174,7 +174,8 @@ local function handler(err, result, ctx)
                     "right_align" or "eol",
                 virt_text = {
                     {virt_text, config.options.tools.inlay_hints.highlight}
-                }
+                },
+                hl_mode = "combine"
             });
 
             -- update state


### PR DESCRIPTION
Inlay hints weren't applying the underlying highlight from the cursorline. Setting `hl_mode="combine"` for the extmark fixes this
