### PR TITLE
Add logging on stderr; Print to dap.repl and :messages

### DIFF
--- a/lua/rust-tools/dap.lua
+++ b/lua/rust-tools/dap.lua
@@ -8,21 +8,25 @@ local M = {}
 function M.get_codelldb_adapter(codelldb_path, liblldb_path)
     return function(callback, _)
         local stdout = vim.loop.new_pipe(false)
+        local stderr = vim.loop.new_pipe(false)
         local handle
         local pid_or_err
         local port
+        local error_message = ""
 
         local opts = {
-            stdio = {nil, stdout},
+            stdio = {nil, stdout, stderr},
             args = {"--liblldb", liblldb_path},
             detached = true
         }
 
         handle, pid_or_err = vim.loop.spawn(codelldb_path, opts, function(code)
             stdout:close()
+            stderr:close()
             handle:close()
             if code ~= 0 then
                 print('codelldb exited with code', code)
+                print('error message', error_message)
             end
         end)
 
@@ -51,7 +55,15 @@ function M.get_codelldb_adapter(codelldb_path, liblldb_path)
                 end
             end
         end)
+        stderr:read_start(function(err, chunk)
+            if chunk then
+                error_message=error_message .. chunk
 
+                vim.schedule(function()
+                    require('dap.repl').append(chunk)
+                end)
+            end
+        end)
     end
 end
 


### PR DESCRIPTION
Currently, occuring errors during `CodeLLDB` configuration are not properly logged, only a message `codelldb exited with code` is displayed. 

This PR changes that behaviour. It registers a new `stderr`, and stores its output in a variable. 
Both, the variable and `stderr` message, are now displayed. The `stderr` message is appended to the `nvim.dap` REPL, while the variable is outputted to normal vim output, i.e. the messages displayed upon `:messages`.