### PR TITLE
feat(hover_actions): add optional support for codeactions

### DIFF
--- a/lua/rust-tools/config.lua
+++ b/lua/rust-tools/config.lua
@@ -91,7 +91,13 @@ local defaults = {
 
             -- whether the hover action window gets automatically focused
             -- default: false
-            auto_focus = false
+            auto_focus = false,
+            -- whether the hover action should include code actions.
+            -- default: false
+            merge_code_actions = false,
+            -- whether to hide server content on a given symbol
+            -- default: false
+            hide_content = false,
         },
 
         -- settings for showing the crate graph based on graphviz and the dot


### PR DESCRIPTION
### Purpose

- Add support for codeActions in hover_actions.
- Add option to ignore hover content.

config:

~~~lua
hover_actions = {
    -- the border that is used for the hover window
    -- see vim.api.nvim_open_win()
    border = {
        {"╭", "FloatBorder"}, {"─", "FloatBorder"},
        {"╮", "FloatBorder"}, {"│", "FloatBorder"},
        {"╯", "FloatBorder"}, {"─", "FloatBorder"},
        {"╰", "FloatBorder"}, {"│", "FloatBorder"}
    },

    -- whether the hover action window gets automatically focused
    -- default: false
    auto_focus = false,
    -- whether the hover action should include code actions.
    -- default: false
    merge_code_actions = false,
    -- whether to hide server content on a given symbol
    -- default: false
    hide_content = false,
},
~~~

### TODO

- Reuse/expose functions in code_actions_groups and remove lspsaga.api