### PR TITLE
fix(standalone): call `on_attach` with correct argument order

### DIFF
--- a/lua/rust-tools/standalone.lua
+++ b/lua/rust-tools/standalone.lua
@@ -14,7 +14,7 @@ function M.start_standalone_client()
 			vim.lsp.buf_attach_client(0, client.id)
 			local on_attach = ra_config.options.server.on_attach
 			if on_attach then
-				on_attach(current_buf, client)
+				on_attach(client, current_buf)
 			end
 			vim.cmd("command! RustSetInlayHints :lua require('rust-tools.inlay_hints').set_inlay_hints()")
 			vim.cmd("command! RustDisableInlayHints :lua require('rust-tools.inlay_hints').disable_inlay_hints()")


### PR DESCRIPTION
The arguments with which `on_attach` is currently called are in the wrong order in this plugin

https://github.com/neovim/nvim-lspconfig/blob/d0263c11e53086242eea72cb76db9fecc6fbc449/lua/lspconfig/configs.lua#L256-L258

The client is the first argument and buffer number the second, rather than being the other way around as was originally done here.