### PR TITLE
feat(executor): Add toggleterm

### DIFF
--- a/lua/rust-tools/executors/init.lua
+++ b/lua/rust-tools/executors/init.lua
@@ -1,9 +1,11 @@
 local termopen = require("rust-tools/executors/termopen")
 local quickfix = require("rust-tools/executors/quickfix")
+local toggleterm = require("rust-tools/executors/toggleterm")
 
 local M = {}
 
 M.termopen = termopen
 M.quickfix = quickfix
+M.toggleterm = toggleterm
 
 return M

--- a/lua/rust-tools/executors/toggleterm.lua
+++ b/lua/rust-tools/executors/toggleterm.lua
@@ -16,6 +16,13 @@ function M.execute_command(command, args, cwd)
 			dir = cwd,
 			cmd = utils.make_command_from_args(command, args),
 			close_on_exit = false,
+      on_open = function(t)
+        -- enter normal mode
+        vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes([[<C-\><C-n>]], true, true, true), "", true)
+
+        -- set close keymap
+        vim.api.nvim_buf_set_keymap(t.bufnr, "n", "q", "<cmd>close<CR>", { noremap = true, silent = true })
+      end,
 		})
 		:toggle()
 end

--- a/lua/rust-tools/executors/toggleterm.lua
+++ b/lua/rust-tools/executors/toggleterm.lua
@@ -1,0 +1,23 @@
+local utils = require("rust-tools.utils.utils")
+
+local M = {}
+
+function M.execute_command(command, args, cwd)
+	local ok, term = pcall(require, "toggleterm.terminal")
+	if not ok then
+		vim.schedule(function()
+			vim.notify("toggleterm not found.", vim.log.levels.ERROR)
+		end)
+		return
+	end
+
+	term.Terminal
+		:new({
+			dir = cwd,
+			cmd = utils.make_command_from_args(command, args),
+			close_on_exit = false,
+		})
+		:toggle()
+end
+
+return M


### PR DESCRIPTION
After run, `toggleterm` will be closed by pressing any key.
Type `<C-\><C-n>` to enter normal mode.
This process can be automated.

```lua
Terminal:new({
  -- dir, cmd, close_on_exit ...
  on_open = function(t)
    -- enter normal mode
    vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes([[<C-\><C-n>]], true, true, true), "", true)

    -- (optional) set close shortcut
    vim.api.nvim_buf_set_keymap(t.bufnr, "n", "q", "<cmd>close<CR>", { noremap = true, silent = true })
  end
})
```

Do you think it's better to add this?