### PR TITLE
fix: `apply_text_edits` requires offset_encoding option

### DIFF
--- a/lua/rust-tools/utils/utils.lua
+++ b/lua/rust-tools/utils/utils.lua
@@ -63,7 +63,7 @@ function M.override_apply_text_edits()
 	local old_func = vim.lsp.util.apply_text_edits
 	vim.lsp.util.apply_text_edits = function(edits, bufnr)
 		M.snippet_text_edits_to_text_edits(edits)
-		old_func(edits, bufnr)
+		old_func(edits, bufnr, "utf16")
 	end
 end
 


### PR DESCRIPTION
Closes https://github.com/simrat39/rust-tools.nvim/issues/127

See:
https://github.com/neovim/neovim/issues/14090#issuecomment-1012005684