### PR TITLE
add bufnr and offset_encoding arguments to join_lines and move_items

### DIFF
--- a/lua/rust-tools/join_lines.lua
+++ b/lua/rust-tools/join_lines.lua
@@ -1,26 +1,30 @@
-local utils = require('rust-tools.utils.utils')
+local utils = require("rust-tools.utils.utils")
 local vim = vim
 
 local M = {}
 
 local function get_params()
-    local params = vim.lsp.util.make_range_params()
-    local range = params.range
+	local params = vim.lsp.util.make_range_params()
+	local range = params.range
 
-    params.range = nil
-    params.ranges = {range}
+	params.range = nil
+	params.ranges = { range }
 
-    return params
+	return params
 end
 
 local function handler(_, result, ctx)
-    vim.lsp.util.apply_text_edits(result, ctx.bufnr)
+	vim.lsp.util.apply_text_edits(
+		result,
+		ctx.bufnr,
+		vim.lsp.get_client_by_id(ctx.client_id).offset_encoding
+	)
 end
 
 -- Sends the request to rust-analyzer to get the TextEdits to join the lines
 -- under the cursor and applies them
 function M.join_lines()
-    utils.request(0, "experimental/joinLines", get_params(), handler)
+	utils.request(0, "experimental/joinLines", get_params(), handler)
 end
 
 return M

--- a/lua/rust-tools/move_item.lua
+++ b/lua/rust-tools/move_item.lua
@@ -1,26 +1,32 @@
 local vim = vim
-local utils = require('rust-tools.utils.utils')
+local utils = require("rust-tools.utils.utils")
 
 local M = {}
 
 local function get_params(up)
-    local direction = up and "Up" or "Down"
-    local params = vim.lsp.util.make_range_params()
-    params.direction = direction
+	local direction = up and "Up" or "Down"
+	local params = vim.lsp.util.make_range_params()
+	params.direction = direction
 
-    return params
+	return params
 end
 
 -- move it baby
-local function handler(_, result)
-    if result == nil then return end
-    utils.snippet_text_edits_to_text_edits(result)
-    vim.lsp.util.apply_text_edits(result)
+local function handler(_, result, ctx)
+	if result == nil then
+		return
+	end
+	utils.snippet_text_edits_to_text_edits(result)
+	vim.lsp.util.apply_text_edits(
+		result,
+		ctx.bufnr,
+		vim.lsp.get_client_by_id(ctx.client_id).offset_encoding
+	)
 end
 
 -- Sends the request to rust-analyzer to move the item and handle the response
 function M.move_item(up)
-    utils.request(0, "experimental/moveItem", get_params(up or false), handler)
+	utils.request(0, "experimental/moveItem", get_params(up or false), handler)
 end
 
 return M


### PR DESCRIPTION
This fixes RustMoveItemUp/Down and RustJoinLines