### PR TITLE
Add on_initialized hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ local opts = {
         -- options right now: termopen / quickfix
         executor = require("rust-tools/executors").termopen,
 
+        -- callback to execute once rust-analyzer is done initializing the workspace
+		-- The callback receives one parameter indicating the `health` of the server: "ok" | "warning" | "error"
+		on_initialized = nil,
+
         runnables = {
             -- whether to use telescope for selection menu or not
             use_telescope = true

--- a/lua/rust-tools/config.lua
+++ b/lua/rust-tools/config.lua
@@ -25,6 +25,10 @@ local defaults = {
 		-- options right now: termopen / quickfix
 		executor = require("rust-tools/executors").termopen,
 
+		-- callback to execute once rust-analyzer is done initializing the workspace
+		-- The callback receives one parameter indicating the `health` of the server: "ok" | "warning" | "error"
+		on_initialized = nil,
+
 		-- These apply to the default RustSetInlayHints command
 		inlay_hints = {
 

--- a/lua/rust-tools/server_status.lua
+++ b/lua/rust-tools/server_status.lua
@@ -4,9 +4,14 @@ local inlay = require("rust-tools.inlay_hints")
 local M = {}
 
 function M.handler(_, result)
-	if result.quiescent and config.options.tools.autoSetHints and not M.ran_once then
-		inlay.set_inlay_hints()
-		require("rust-tools.inlay_hints").setup_autocmd()
+	if result.quiescent and not M.ran_once then
+		if config.options.tools.autoSetHints then
+			inlay.set_inlay_hints()
+			require("rust-tools.inlay_hints").setup_autocmd()
+		end
+		if config.options.tools.on_initialized then
+			config.options.tools.on_initialized(result)
+		end
 		M.ran_once = true
 	end
 end


### PR DESCRIPTION
Addresses a common issue with large workspaces that take longer to load and cause errors such as:
https://github.com/rust-analyzer/rust-analyzer/issues/10910
https://www.reddit.com/r/neovim/comments/qwlheb/delay_vimlspcodelensrefresh_until_rustanalyzer_is/

This works by allowing passing a callback to be run once `serverStatus` with `quiescent` is sent (similar to inlayHints)

An example configuration:
```lua
tools = {
  on_initialized = function()
    vim.cmd([[
      augroup SuperDuperAus
        autocmd CursorHold                      *.rs silent! lua vim.lsp.buf.document_highlight()
        autocmd CursorMoved,InsertEnter         *.rs silent! lua vim.lsp.buf.clear_references()
        autocmd BufEnter,CursorHold,InsertLeave *.rs silent! lua vim.lsp.codelens.refresh()
        autocmd BufWritePre                     *.rs silent! lua vim.lsp.buf.formatting_sync()
      augroup END
    ]])
  end,
}
```
