### PR TITLE
Fix nil border

### DIFF
--- a/lua/rust-tools/hover_actions.lua
+++ b/lua/rust-tools/hover_actions.lua
@@ -82,7 +82,7 @@ function M.handler(_, result)
 	end
 
 	local bufnr, winnr = util.open_floating_preview(markdown_lines, "markdown", {
-		border = config.options.tools.hover_actions.border,
+		border = next(config.options.tools.hover_actions.border) and config.options.tools.hover_actions.border or nil,
 		focusable = true,
 		focus_id = "rust-tools-hover-actions",
 		close_events = { "CursorMoved", "BufHidden", "InsertCharPre" },


### PR DESCRIPTION
Adds a "empty map" check on the border.

Previously, if the user removed the border with `border = {}`, the script would crash.
Else, if the user tried to remove the border with `border = nil`, the default config would kick in, essentially overriding the user's configuration.