### PR TITLE
fix: Gracefully handle <esc> in vim.ui.select()

### DIFF
--- a/lua/rust-tools/debuggables.lua
+++ b/lua/rust-tools/debuggables.lua
@@ -79,6 +79,9 @@ local function handler(_, result)
     options,
     { prompt = "Debuggables", kind = "rust-tools/debuggables" },
     function(_, choice)
+      if choice == nil then
+        return
+      end
       local args = result[choice].args
       rt_dap.start(args)
     end

--- a/lua/rust-tools/runnables.lua
+++ b/lua/rust-tools/runnables.lua
@@ -40,8 +40,8 @@ local function getCommand(c, results)
 end
 
 function M.run_command(choice, result)
-  -- do nothing if choice is too high or too low
-  if choice < 1 or choice > #result then
+  -- do nothing if choice is nil (e.g., the user pressed <esc>) or too high or too low
+  if choice == nil or choice < 1 or choice > #result then
     return
   end
 


### PR DESCRIPTION
This fixes the errors raised when the user runs RustRunnables or
RustDebuggables and presses <esc> instead of typing a number or pressing
'q'