### PR TITLE
fix(inlay_hints): Fix inlay_hints.only_current_line = true

### DIFF
--- a/lua/rust-tools/inlay_hints.lua
+++ b/lua/rust-tools/inlay_hints.lua
@@ -90,7 +90,7 @@ local function parseHints(result)
     end
 
     if only_current_line then
-      if line == tostring(current_line - 1) then
+      if line == current_line - 1 then
         add_line()
       end
     else


### PR DESCRIPTION
Due some changes in rust-analyzer inlay hints for current line stopped working for me.
```
inlay_hints = {
	only_current_line = true,
	only_current_line_autocmd = "CursorHold",
        ...
}
```
This PR somehow fix this.