### PR TITLE
fix(0.8): Breaking change in c618b314

### DIFF
--- a/lua/rust-tools/code_action_group.lua
+++ b/lua/rust-tools/code_action_group.lua
@@ -40,8 +40,8 @@ function M.on_user_choice(action_tuple, ctx)
   if
     not action.edit
     and client
-    and type(client.resolved_capabilities.code_action) == "table"
-    and client.resolved_capabilities.code_action.resolveProvider
+    and type(client.server_capabilities.code_action) == "table"
+    and client.server_capabilities.code_action.resolveProvider
   then
     client.request("codeAction/resolve", action, function(err, resolved_action)
       if err then


### PR DESCRIPTION
This fixes the breaking change in the latest Neovim 0.8 build.

`resolved_capabilities` is now deprecated. `server_capabilities` should be used
instead.

See: c618b314c6a266806edf692122b16ba9ff7a8e10
