### PR TITLE
add RustOpenExternalDocs to open docs for element under the cursor 

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ RustDebuggables
 RustViewCrateGraph
 RustReloadWorkspace
 RustSSR
+RustOpenExternalDocs
 ```
 
 ## Standalone File Support

--- a/lua/rust-tools.lua
+++ b/lua/rust-tools.lua
@@ -15,6 +15,9 @@ local function setup_commands()
     RustSetInlayHints = {
       require("rust-tools.inlay_hints").set_inlay_hints,
     },
+    RustOpenExternalDocs= {
+      require("rust-tools.external_docs").open_external_docs,
+    },
     RustDisableInlayHints = {
       require("rust-tools.inlay_hints").disable_inlay_hints,
     },

--- a/lua/rust-tools/external_docs.lua
+++ b/lua/rust-tools/external_docs.lua
@@ -1,0 +1,17 @@
+local M = {}
+local utils = require("rust-tools.utils.utils")
+
+function M.open_external_docs()
+  utils.request(
+    0,
+    "experimental/externalDocs",
+    vim.lsp.util.make_position_params(),
+    function(_, url)
+      if url then
+        vim.fn["netrw#BrowseX"](url, 0)
+      end
+    end
+  )
+end
+
+return M


### PR DESCRIPTION
I recently discovered a solution for the problem I had already exists inside rust-analyzer ( https://github.com/rust-lang/rust-analyzer/pull/5917 ). 

This adds the command to this plugin. 

I'm happy to apply any needed changes. 