### PR TITLE
Adding floating window support

### DIFF
--- a/lua/rust-tools/config.lua
+++ b/lua/rust-tools/config.lua
@@ -189,6 +189,15 @@ local defaults = {
       name = "rt_lldb",
     },
   },
+
+  window = {
+    width = 0.9, -- width ratio
+    height = 0.9, -- height ratio
+    max_width = 200, -- max width of the terminal window
+    max_height = 60, -- max height of the terminal window
+    border = "single", -- Border style for the terminal window (see `:h nvim_open_win`)
+    floating = false, -- Define if the terminal window should be floating or not (disabled by default)
+  }
 }
 
 M.options = {

--- a/lua/rust-tools/executors/termopen.lua
+++ b/lua/rust-tools/executors/termopen.lua
@@ -4,7 +4,13 @@ local M = {}
 
 local latest_buf_id = nil
 
+local function get_height()
+  return math.ceil(uis[1].height / 3)
+end
+
 function M.execute_command(command, args, cwd)
+  local config = require("rust-tools.config").options
+
   local full_command = utils.chain_commands({
     utils.make_command_from_args("cd", { cwd }),
     utils.make_command_from_args(command, args),
@@ -17,12 +23,6 @@ function M.execute_command(command, args, cwd)
   -- create the new buffer
   latest_buf_id = vim.api.nvim_create_buf(false, true)
 
-  -- split the window to create a new buffer and set it to our window
-  utils.split(false, latest_buf_id)
-
-  -- make the new buffer smaller
-  utils.resize(false, "-5")
-
   -- close the buffer when escape is pressed :)
   vim.api.nvim_buf_set_keymap(
     latest_buf_id,
@@ -31,6 +31,37 @@ function M.execute_command(command, args, cwd)
     ":q<CR>",
     { noremap = true }
   )
+
+
+  local is_floating = config.window.floating
+
+  if is_floating then
+ 
+    local ui_width = vim.api.nvim_win_get_width(0)
+    local ui_height = vim.api.nvim_win_get_height(0)
+
+    local width = math.min(math.ceil(ui_width * config.window.width), config.window.max_width)
+    local height = math.min(math.ceil(ui_height * config.window.height), config.window.max_height)
+
+    local opts = {
+      relative = 'editor',
+      width = width,
+      height = height,
+      col = (ui_width/2) - (width/2),
+      row = (ui_height/2) - (height/2),
+      anchor = 'NW',
+      style = 'minimal',
+      border = config.window.border,
+    }
+
+    local win = vim.api.nvim_open_win(latest_buf_id, 1, opts)
+  else
+    -- split the window to create a new buffer and set it to our window
+    utils.split(false, latest_buf_id)
+
+    -- make the new buffer smaller
+    utils.resize(false, "-5")
+  end
 
   -- run the command
   vim.fn.termopen(full_command)


### PR DESCRIPTION
This PR aims to add the floating window support for terminal actions (like `RustDebuggables`, `RustRunnables` and so on).

The floating window can be configured:

```lua
local config = {
  ...
  window = {
    width = 0.9, -- width ratio
    height = 0.9, -- height ratio
    max_width = 200, -- max width of the terminal window
    max_height = 60, -- max height of the terminal window
    border = "single", -- Border style for the terminal window (see `:h nvim_open_win`)
    floating = false, -- Define if the terminal window should be floating or not (disabled by default)
  }
}
```

Feel free to suggest modifications :)

Signed-off-by: Freyskeyd <simon.paitrault@gmail.com>