### PR TITLE
allow user to reuse on attach bindings

### DIFF
--- a/lua/rust-tools.lua
+++ b/lua/rust-tools.lua
@@ -144,8 +144,11 @@ local function setup_capabilities()
   )
 end
 
-local function setup_lsp()
-  nvim_lsp.rust_analyzer.setup(config.options.server)
+-- allow user to use their on attach, reuse the one used for other LSP server
+local function setup_lsp(on_attach)
+
+  stp = vim.tbl_deep_extend("force", config.options.server, { on_attach = on_attach })
+  nvim_lsp.rust_analyzer.setup(stp)
 end
 
 local function get_root_dir(filename)
@@ -198,7 +201,7 @@ function M.start_standalone_if_required()
   end
 end
 
-function M.setup(opts)
+function M.setup(opts, on_attach)
   config.setup(opts)
 
   setup_capabilities()
@@ -211,7 +214,7 @@ function M.setup(opts)
   -- setup user commands
   setup_commands()
   -- setup rust analyzer
-  setup_lsp()
+  setup_lsp(on_attach)
 
   lcommands.setup_lsp_commands()
 


### PR DESCRIPTION
while I was using this I wasn't able to reuse my existing key bindings without having to remap for the exposed functions in this plugin.

I already had bunch of on_attach bindings used for golang, wanted to reuse it without having to rewrite manually. So I have added another field to setup where it can accept on_attach functions and use it while setting up rust analyzer.
```
local on_attach = function(client, bufnr)
  local function buf_set_keymap(...) vim.api.nvim_buf_set_keymap(bufnr, ...) end
  local function buf_set_option(...) vim.api.nvim_buf_set_option(bufnr, ...) end

  --Enable completion triggered by <c-x><c-o>
  buf_set_option( 'omnifunc', 'v:lua.vim.lsp.omnifunc')

  -- Mappings.
  local opts = { noremap=true, silent=true }


  buf_set_keymap('n', 'gD', '<Cmd>lua vim.lsp.buf.declaration()<CR>', opts)
  buf_set_keymap('n', 'gd', '<Cmd>lua vim.lsp.buf.definition()<CR>', opts)
  buf_set_keymap('n', 'K', '<Cmd>lua vim.lsp.buf.hover()<CR>', opts)
  buf_set_keymap('n', 'U', '<Cmd>lua vim.lsp.buf.hover()<CR>', opts)
  ....
end

require('rust-tools').setup({},  on_attach)
```
Ask: if there was a way already provided to do this, let me know.

Thanks in advance
