### PR TITLE
feat: Add last runnables

### DIFF
--- a/lua/rust-tools/config.lua
+++ b/lua/rust-tools/config.lua
@@ -170,6 +170,9 @@ local defaults = {
         "x11",
       },
     },
+
+    -- should cache test or debug commands to run
+    cache = false
   },
 
   -- all the opts to send to nvim-lspconfig

--- a/lua/rust-tools/hover_actions.lua
+++ b/lua/rust-tools/hover_actions.lua
@@ -30,6 +30,10 @@ function M.execute_rust_analyzer_command(action)
   local fn = vim.lsp.commands[action.command]
   if fn then
     fn(action)
+
+    if config.options.tools.cache then
+      require("rust-tools.utils.cache").set_last_runnable(action)
+    end
   end
 end
 

--- a/lua/rust-tools/utils/cache.lua
+++ b/lua/rust-tools/utils/cache.lua
@@ -1,0 +1,25 @@
+local M = {}
+
+local cache = {
+  last_runnable = nil,
+}
+
+-- @param action 
+M.set_last_runnable = function(action)
+  cache.last_runnable = action
+end
+
+M.execute_last_runnable = function()
+  local action = cache.last_runnable
+
+  -- see hover_actions.lua execute_rust_analyzer_command
+  if action then 
+    local fn = vim.lsp.commands[action.command]
+
+    if fn then 
+      fn(action)
+    end
+  end
+end
+
+return M


### PR DESCRIPTION
This allows users to run runnables that were run previously.
Example: Running previous test runnable and not needing to return
the cursor to the function position.

---

Would love feedback on this feature. Things like where should it be, how things are named, configuration options, and any other feedback. I put it into the hover menu because that's what I started to use, but there's also runnables.lua where this may work better or in addition to hover_actions.lua. 

Thank you!
