### PR TITLE
fix: add utils.close_win(winnr) for safer win deletion

### DIFF
--- a/lua/rust-tools/code_action_group.lua
+++ b/lua/rust-tools/code_action_group.lua
@@ -1,3 +1,4 @@
+local utils = require("rust-tools.utils.utils")
 local M = {}
 
 ---@private
@@ -38,7 +39,7 @@ function M.on_user_choice(action_tuple, ctx)
   local client = vim.lsp.get_client_by_id(action_tuple[1])
   local action = action_tuple[2]
   local code_action_provider = nil
-  if vim.fn.has('nvim-0.8.0') then
+  if vim.fn.has("nvim-0.8.0") then
     code_action_provider = client.server_capabilities.codeActionProvider
   else
     code_action_provider = client.resolved_capabilities.code_action
@@ -258,19 +259,19 @@ function M.on_secondary_quit()
   -- and errors out
   M.state.secondary.clear()
 
-  vim.api.nvim_win_close(winnr, true)
+  utils.close_win(winnr)
 end
 
 function M.cleanup()
   vim.cmd([[autocmd! RustToolsCodeActions]])
 
   if M.state.primary.winnr then
-    vim.api.nvim_win_close(M.state.primary.winnr, true)
+    utils.close_win(M.state.primary.winnr)
     M.state.primary.clear()
   end
 
   if M.state.secondary.winnr then
-    vim.api.nvim_win_close(M.state.secondary.winnr, true)
+    utils.close_win(M.state.secondary.winnr)
     M.state.secondary.clear()
   end
 
@@ -287,9 +288,7 @@ function M.on_cursor_move()
       M.state.active_group_index = line
 
       if M.state.secondary.winnr then
-        if vim.api.nvim_win_is_valid(M.state.secondary.winnr) then
-          vim.api.nvim_win_close(M.state.secondary.winnr, true)
-        end
+        utils.close_win(M.state.secondary.winnr)
         M.state.secondary.clear()
       end
 
@@ -351,9 +350,7 @@ function M.on_cursor_move()
     end
 
     if M.state.secondary.winnr then
-      if vim.api.nvim_win_is_valid(M.state.secondary.winnr) then
-        vim.api.nvim_win_close(M.state.secondary.winnr, true)
-      end
+      utils.close_win(M.state.secondary.winnr)
       M.state.secondary.clear()
     end
   end

--- a/lua/rust-tools/hover_actions.lua
+++ b/lua/rust-tools/hover_actions.lua
@@ -34,9 +34,7 @@ function M.execute_rust_analyzer_command(action)
 end
 
 function M._close_hover()
-  if M._state.winnr ~= nil then
-    vim.api.nvim_win_close(M._state.winnr, true)
-  end
+  utils.close_win(M._state.winnr)
 end
 
 local function parse_commands()

--- a/lua/rust-tools/utils/utils.lua
+++ b/lua/rust-tools/utils/utils.lua
@@ -39,8 +39,14 @@ function M.chain_commands(commands)
 end
 
 function M.delete_buf(bufnr)
-  if bufnr ~= nil then
+  if bufnr ~= nil and vim.api.nvim_buf_is_valid(bufnr) then
     vim.api.nvim_buf_delete(bufnr, { force = true })
+  end
+end
+
+function M.close_win(winnr)
+  if winnr ~= nil and vim.api.nvim_win_is_valid(winnr) then
+    vim.api.nvim_win_close(winnr, true)
   end
 end
 


### PR DESCRIPTION
Hello! I've been running into issues like these (admittedly because I sometimes hijack the hover buffer contents into a different preview window): 

```
E5108: Error executing lua ...r/start/rust-tools.nvim/lua/rust-tools/hover_actions.lua:38: Invalid window id: 1051
stack traceback:
        [C]: in function 'nvim_win_close'
        ...r/start/rust-tools.nvim/lua/rust-tools/hover_actions.lua:38: in function '_close_hover'
        [string ":lua"]:1: in main chunk
```

I figured something like this would make sense? For me personally it'd be ideal if it'd also support loading the hover buffer into a different window (like a preview window) - right now there are some places where it assumes the buffer is still associated with the (now closed) floating window, but that's a separate PR