### PR TITLE
fix(hover_actions): use current window to gather cursor position

### DIFF
--- a/lua/rust-tools/hover_actions.lua
+++ b/lua/rust-tools/hover_actions.lua
@@ -14,7 +14,8 @@ local set_keymap_opt = { noremap = true, silent = true }
 -- run the command under the cursor, if the thing under the cursor is not the
 -- command then do nothing
 function M._run_command()
-  local line = vim.api.nvim_win_get_cursor(M._state.winnr)[1]
+  local winnr = vim.api.nvim_get_current_win()
+  local line = vim.api.nvim_win_get_cursor(winnr)[1]
 
   if line > #M._state.commands then
     return


### PR DESCRIPTION
This is to support scenarios where the buffer that was loaded into the
hover floating window has been moved into another window (for example a
preview window).

Instead of assuming that the buffer is still viewed in the floating
window, we now just use the current window to gather the cursor position.

Example of how I send the contents of the floating hover to a preview
window when hitting the hover keymap twice (instead of entering the
floating window): https://asciinema.org/a/szIURrM5er4XvGyvJXjcPHUAq