### PR TITLE
feat(config): allow disabling reload workspace autocmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,9 @@ local opts = {
     -- The callback receives one parameter indicating the `health` of the server: "ok" | "warning" | "error"
     on_initialized = nil,
 
+    -- automatically call RustReloadWorkspace when writing to a Cargo.toml file.
+    reload_workspace_from_cargo_toml = true,
+
     -- These apply to the default RustSetInlayHints command
     inlay_hints = {
       -- automatically set inlay hints (type hints)

--- a/lua/rust-tools/config.lua
+++ b/lua/rust-tools/config.lua
@@ -18,6 +18,9 @@ local defaults = {
     -- The callback receives one parameter indicating the `health` of the server: "ok" | "warning" | "error"
     on_initialized = nil,
 
+    -- automatically call RustReloadWorkspace when writing to a Cargo.toml file.
+    reload_workspace_from_cargo_toml = true,
+
     -- These apply to the default RustSetInlayHints command
     inlay_hints = {
       -- automatically set inlay hints (type hints)

--- a/lua/rust-tools/lsp.lua
+++ b/lua/rust-tools/lsp.lua
@@ -6,18 +6,21 @@ local server_status = require("rust-tools.server_status")
 local M = {}
 
 local function setup_autocmds()
-  vim.cmd([[
-        augroup RustToolsAutocmds
-            au!
-  ]])
-  if config.options.tools.reload_workspace_from_cargo_toml then
-    vim.cmd([[ autocmd BufWritePost */Cargo.toml lua require('rust-tools/workspace_refresh')._reload_workspace_from_cargo_toml() ]])
+  local group = vim.api.nvim_create_augroup("RustToolsAutocmds", { clear = true })
+
+  if rt.config.options.tools.reload_workspace_from_cargo_toml then
+    vim.api.nvim_create_autocmd("BufWritePost", {
+      pattern = "*/Cargo.toml",
+      callback = require('rust-tools/workspace_refresh')._reload_workspace_from_cargo_toml,
+      group = group,
+    })
   end
-  vim.cmd([[
-            autocmd VimEnter *.rs lua require('rust-tools').lsp.start_standalone_if_required()
-        augroup END
-        redraw
-  ]])
+
+  vim.api.nvim_create_autocmd("VimEnter", {
+    pattern = "*.rs",
+    callback = rt.lsp.start_standalone_if_required,
+    group = group,
+  });
 end
 
 local function setup_commands()

--- a/lua/rust-tools/lsp.lua
+++ b/lua/rust-tools/lsp.lua
@@ -5,6 +5,21 @@ local server_status = require("rust-tools.server_status")
 
 local M = {}
 
+local function setup_autocmds()
+  vim.cmd([[
+        augroup RustToolsAutocmds
+            au!
+  ]])
+  if config.options.tools.reload_workspace_from_cargo_toml then
+    vim.cmd([[ autocmd BufWritePost */Cargo.toml lua require('rust-tools/workspace_refresh')._reload_workspace_from_cargo_toml() ]])
+  end
+  vim.cmd([[
+            autocmd VimEnter *.rs lua require('rust-tools').lsp.start_standalone_if_required()
+        augroup END
+        redraw
+  ]])
+end
+
 local function setup_commands()
   local lsp_opts = rt.config.options.server
 
@@ -197,6 +212,8 @@ function M.start_standalone_if_required()
 end
 
 function M.setup()
+  setup_autocmds()
+  -- setup capabilities
   setup_capabilities()
   -- setup on_init
   setup_on_init()

--- a/plugin/rust-tools.vim
+++ b/plugin/rust-tools.vim
@@ -1,2 +1,0 @@
-autocmd BufWritePost */Cargo.toml lua require('rust-tools/workspace_refresh')._reload_workspace_from_cargo_toml()
-autocmd VimEnter *.rs lua require('rust-tools').lsp.start_standalone_if_required()


### PR DESCRIPTION
This PR adds the option `reload_workspace_from_cargo_toml` (default to `true`, to keep the current behavior) to the config, that controls if the `autocmd BufWritePost */Cargo.toml` should be created.

I fell inclined to create this because of a broken workflow in one of my projects, I need to edit a field in Cargo.toml (that don't impact autocomplete) multiple times. But I also think that always reloading the workspace when editing the Cargo.toml file was triggering too many false-positives.

This PR also removed the `plugin\rust-tools.vim` file, and replace it by a lua function that set the autocmds (including the `BufWritePost */Cargo.toml`, conditionally).