### PR TITLE
fix: nil check for runnable and debuggable handler methods closes #217

### DIFF
--- a/lua/rust-tools/debuggables.lua
+++ b/lua/rust-tools/debuggables.lua
@@ -72,6 +72,9 @@ local function sanitize_results_for_debugging(result)
 end
 
 local function handler(_, result)
+  if result == nil then
+    return
+  end
   result = sanitize_results_for_debugging(result)
 
   local options = get_options(result)

--- a/lua/rust-tools/runnables.lua
+++ b/lua/rust-tools/runnables.lua
@@ -53,6 +53,9 @@ function M.run_command(choice, result)
 end
 
 local function handler(_, result)
+  if result == nil then
+    return
+  end
   -- get the choice from the user
   local options = get_options(result)
   vim.ui.select(options, { prompt = "Runnables", kind = "rust-tools/runnables" }, function(_, choice)


### PR DESCRIPTION
When I have another lang server active that doesn't register any runnables/debuggables the result comes back nil, this nil value is then passed along to a function that tries to loop over the nil value. 