### PR TITLE
Fix error which occurs when vim is loaded too fast

### DIFF
--- a/lua/rust-tools/lsp.lua
+++ b/lua/rust-tools/lsp.lua
@@ -15,12 +15,16 @@ local function setup_autocmds()
       group = group,
     })
   end
-
-  vim.api.nvim_create_autocmd("VimEnter", {
-    pattern = "*.rs",
-    callback = rt.lsp.start_standalone_if_required,
-    group = group,
-  });
+  
+  if vim.v.vim_did_enter then
+    rt.lsp.start_standalone_if_required()
+  else
+    vim.api.nvim_create_autocmd("VimEnter", {
+      pattern = "*.rs",
+      callback = rt.lsp.start_standalone_if_required,
+      group = group,
+    });
+  end
 end
 
 local function setup_commands()


### PR DESCRIPTION
Without this change, the standalone server does not start for me.
See vim docs for `*VimEnter*`.