### PR TITLE
Fix running a debugger when a debuggee needs input

### DIFF
--- a/lua/rust-tools/commands.lua
+++ b/lua/rust-tools/commands.lua
@@ -17,6 +17,7 @@ function M.setup_lsp_commands()
   end
 
   vim.lsp.commands["rust-analyzer.debugSingle"] = function(command)
+    rt.utils.sanitize_command_for_debugging(command.arguments[1].args.cargoArgs)
     rt.dap.start(command.arguments[1].args)
   end
 end

--- a/lua/rust-tools/debuggables.lua
+++ b/lua/rust-tools/debuggables.lua
@@ -59,11 +59,7 @@ local function sanitize_results_for_debugging(result)
   end, result)
 
   for i, value in ipairs(ret) do
-    if value.args.cargoArgs[1] == "run" then
-      ret[i].args.cargoArgs[1] = "build"
-    elseif value.args.cargoArgs[1] == "test" then
-      table.insert(ret[i].args.cargoArgs, 2, "--no-run")
-    end
+    rt.utils.sanitize_command_for_debugging(value.args.cargoArgs)
   end
 
   return ret

--- a/lua/rust-tools/utils/utils.lua
+++ b/lua/rust-tools/utils/utils.lua
@@ -132,4 +132,21 @@ function M.is_ra_server(client)
     or client.name == "rust_analyzer-standalone"
 end
 
+
+-- sanitize_command_for_debugging substitudes the command arguments so it can be used to run a
+-- debugger.
+--
+-- @param command should be a table like: { "run", "--package", "<program>", "--bin", "<program>" }
+-- For some reason the endpoint textDocument/hover from rust-analyzer returns
+-- cargoArgs = { "run", "--package", "<program>", "--bin", "<program>" } for Debug entry.
+-- It doesn't make any sense to run a program before debugging.  Even more the debuggin won't run if
+-- the program waits some input.  Take a look at rust-analyzer/editors/code/src/toolchain.ts.
+function M.sanitize_command_for_debugging(command)
+  if command[1] == "run" then
+    command[1] = "build"
+  elseif command[1] == "test" then
+    table.insert(command, 2, "--no-run")
+  end
+end
+
 return M


### PR DESCRIPTION
The endpoint of Rust Analyzer textDocument/hover returns commands to run
the program.  It doesn't work for debugging because we have to build and
only then run the program within a debugger.  The arguments are
corrected to achieve that.

Rebased duplicate of https://github.com/simrat39/rust-tools.nvim/pull/226

