### PR TITLE
Allow passing arguments to a debugger

### DIFF
--- a/lua/rust-tools/dap.lua
+++ b/lua/rust-tools/dap.lua
@@ -100,7 +100,19 @@ function M.start(args)
                 -- https://www.kernel.org/doc/html/latest/admin-guide/LSM/Yama.html
                 runInTerminal = false,
               }
-              dap.run(dap_config)
+              if args.cargoArgs[1] == "build" or args.cargoArgs[1] == "run" then
+                vim.ui.input({ prompt = "Input arguments" }, function(input)
+                  if not input then
+                    input = ""
+                  end
+                  for m in input:gmatch("%S+") do
+                    table.insert(dap_config.args, m)
+                  end
+                  dap.run(dap_config)
+                end)
+              else
+                dap.run(dap_config)
+              end
               break
             end
           end


### PR DESCRIPTION
Closes #241

Two notes:
1. I have to split an input string by whitespace. Passing it as a whole in a table just doesn't work because a debuggee doesn't receive these arguments. E.g.:
```lua
args = { input }
```
3. ```vim.ui.input()``` is evidently async. No idea how to make caller wait for the closure to return. That's why:
```lua
if --[[cond]] then
  -- code
    dap.run(dap_config)
  end)
else
  dap.run(dap_config)
end
```

Otherwise it works just fine.