### PR TITLE
Added filetypes field to standalone client config

### DIFF
--- a/lua/rust-tools/standalone.lua
+++ b/lua/rust-tools/standalone.lua
@@ -8,6 +8,7 @@ function M.start_standalone_client()
     ),
     capabilities = rt.config.options.server.capabilities,
     cmd = rt.config.options.server.cmd or { "rust-analyzer" },
+    filetypes = { "rust" },
     init_options = { detachedFiles = { vim.api.nvim_buf_get_name(0) } },
     name = "rust_analyzer-standalone",
     on_init = function(client)


### PR DESCRIPTION
Statusline plugins use `filetypes` field to identify whether a given server belongs to a particular filetype or not. This helps them only display relevant server names to the statusline.