### PR TITLE
Bug: Newlines in Code Action title

### DIFF
--- a/lua/rust-tools/code_action_group.lua
+++ b/lua/rust-tools/code_action_group.lua
@@ -164,13 +164,15 @@ local function on_code_action_results(results, ctx)
   for _, value in pairs(M.state.actions.ungrouped) do
     local action = value[2]
     value[2].idx = idx
-    vim.api.nvim_buf_set_lines(
-      M.state.primary.bufnr,
-      -1,
-      -1,
-      false,
-      { action.title }
-    )
+    for s in string.gmatch(action.title, "[^\r\n]+") do
+      vim.api.nvim_buf_set_lines(
+        M.state.primary.bufnr,
+        -1,
+        -1,
+        false,
+        { s }
+      )
+    end
     idx = idx + 1
   end
 


### PR DESCRIPTION
Fixes issue putting new lines from a code action title in the code action box -- it does not accept newlines

Can be reproduced with `:RustCodeAction` on a hint that has a multiline title (e.g. "collapse nested if block:")

```
Error executing vim.schedule lua callback: ...opt/rust-tools.nvim/lua/rust-tools/code_action_group.lua:167: String cannot contain newlines                                               
stack traceback:                                                                                                                                                                         
        [C]: in function 'nvim_buf_set_lines'                                                                                                                                            
        ...opt/rust-tools.nvim/lua/rust-tools/code_action_group.lua:167: in function 'on_code_action_results'                                                                            
        ...opt/rust-tools.nvim/lua/rust-tools/code_action_group.lua:376: in function 'callback'                                                                                          
        ...Cellar/neovim/0.7.2_1/share/nvim/runtime/lua/vim/lsp.lua:1535: in function 'handler'                                                                                          
        ...Cellar/neovim/0.7.2_1/share/nvim/runtime/lua/vim/lsp.lua:1025: in function ''                                                                                                 
        vim/_editor.lua: in function <vim/_editor.lua:0>  
```

Fix puts title newlines on a new line of the code action box -- but any line after the first is not active. Also dosen't look very nice :)