### PR TITLE
fix: don't render invalid buffer's inlayHint

### DIFF
--- a/doc/rust-tools.txt
+++ b/doc/rust-tools.txt
@@ -1,4 +1,4 @@
-*rust-tools.txt*         For NVIM v0.5.0        Last change: 2022 September 02
+*rust-tools.txt*          For NVIM v0.5.0         Last change: 2022 October 13
 
 ==============================================================================
 Table of Contents                               *rust-tools-table-of-contents*

--- a/lua/rust-tools/inlay_hints.lua
+++ b/lua/rust-tools/inlay_hints.lua
@@ -160,6 +160,11 @@ function M.cache_render(self, bufnr)
             return
           end
 
+          if not vim.api.nvim_buf_is_valid(ctx.bufnr) then
+            self.cache[ctx.bufnr] = nil
+            return
+          end
+
           self.cache[ctx.bufnr] = parse_hints(result)
 
           M.render(self, ctx.bufnr)


### PR DESCRIPTION
Fixes the race between inlayHint request and buffer invalidation.

Fixes #249 