### PR TITLE
fix: lua require paths

### DIFF
--- a/lua/rust-tools/config.lua
+++ b/lua/rust-tools/config.lua
@@ -12,7 +12,7 @@ local defaults = {
 
     -- how to execute terminal commands
     -- options right now: termopen / quickfix
-    executor = require("rust-tools/executors").termopen,
+    executor = require("rust-tools.executors").termopen,
 
     -- callback to execute once rust-analyzer is done initializing the workspace
     -- The callback receives one parameter indicating the `health` of the server: "ok" | "warning" | "error"

--- a/lua/rust-tools/executors/init.lua
+++ b/lua/rust-tools/executors/init.lua
@@ -1,6 +1,6 @@
-local termopen = require("rust-tools/executors/termopen")
-local quickfix = require("rust-tools/executors/quickfix")
-local toggleterm = require("rust-tools/executors/toggleterm")
+local termopen = require("rust-tools.executors.termopen")
+local quickfix = require("rust-tools.executors.quickfix")
+local toggleterm = require("rust-tools.executors.toggleterm")
 
 local M = {}
 

--- a/lua/rust-tools/lsp.lua
+++ b/lua/rust-tools/lsp.lua
@@ -11,7 +11,7 @@ local function setup_autocmds()
   if rt.config.options.tools.reload_workspace_from_cargo_toml then
     vim.api.nvim_create_autocmd("BufWritePost", {
       pattern = "*/Cargo.toml",
-      callback = require('rust-tools/workspace_refresh')._reload_workspace_from_cargo_toml,
+      callback = require('rust-tools.workspace_refresh')._reload_workspace_from_cargo_toml,
       group = group,
     })
   end


### PR DESCRIPTION
On Windows the lua require calls fail when using slashes, but replacing them with dots works.