### PR TITLE
Change command chain operator for nushell

### DIFF
--- a/lua/rust-tools/utils/utils.lua
+++ b/lua/rust-tools/utils/utils.lua
@@ -5,6 +5,13 @@ function M.is_windows()
   return sysname == "Windows" or sysname == "Windows_NT"
 end
 
+function M.is_nushell()
+    local shell = vim.loop.os_getenv("SHELL")
+    local nu = "nu"
+    -- Check if $SHELL ends in "nu"
+    return shell:sub(-string.len(nu)) == nu
+end
+
 ---comment
 ---@param command string
 ---@param args table
@@ -22,7 +29,9 @@ end
 ---Note that a space is not added at the end of the returned command string
 ---@param commands table
 function M.chain_commands(commands)
-  local separator = M.is_windows() and " | " or " && "
+  local separator = M.is_windows() and " | "
+    or M.is_nushell() and ";"
+    or " && "
   local ret = ""
 
   for i, value in ipairs(commands) do


### PR DESCRIPTION
When using [nushell](https://www.nushell.sh), chaining command with `&&` does not work as it is not a supported operator. The replacement for `&&` in nushell is `;`, see [Coming from Bash](https://www.nushell.sh/book/coming_from_bash.html).

This PR adds a check if the current shell (as defined by the environment variable $SHELL) is `nu`. If that's the case, we use `;` as the command chaining operator.

I am not a lua programmer so this is a best effort fix. Please let me know if I can improve anything.