### PR TITLE
Respect `right_align_padding`.

### DIFF
--- a/lua/rust-tools/inlay_hints.lua
+++ b/lua/rust-tools/inlay_hints.lua
@@ -227,6 +227,9 @@ local function render_line(line, line_hints, bufnr)
   -- set the virtual text if it is not empty
   if virt_text ~= "" then
     ---@diagnostic disable-next-line: param-type-mismatch
+    if opts.right_align then
+      virt_text = virt_text .. string.rep(" ", opts.right_align_padding)
+    end
     vim.api.nvim_buf_set_extmark(bufnr, M.namespace, line, 0, {
       virt_text_pos = opts.right_align and "right_align" or "eol",
       virt_text = {


### PR DESCRIPTION
`right_align_padding` is documented in rust-tools' `inlay_hints` but, at least on neovim 0.8, has no effect. This commit explicitly adds padding as spaces.