### PR TITLE
fix: fixed inlayhint is not working

### DIFF
--- a/lua/rust-tools/inlay_hints.lua
+++ b/lua/rust-tools/inlay_hints.lua
@@ -150,7 +150,7 @@ end
 function M.cache_render(self, bufnr)
   local buffer = bufnr or vim.api.nvim_get_current_buf()
 
-  for _, v in ipairs(vim.lsp.buf_get_clients(buffer)) do
+  for _, v in pairs(vim.lsp.buf_get_clients(buffer)) do
     if rt.utils.is_ra_server(v) then
       v.request(
         "textDocument/inlayHint",


### PR DESCRIPTION
Fixed an issue where the iterator could not traverse the client list causing the inlayhint to fail. #295