### PR TITLE
fix(debuggables): check for `nil` value in selection handler

### DIFF
--- a/lua/rust-tools/debuggables.lua
+++ b/lua/rust-tools/debuggables.lua
@@ -76,6 +76,10 @@ local function handler(_, result)
     options,
     { prompt = "Debuggables", kind = "rust-tools/debuggables" },
     function(_, choice)
+      if choice == nil then
+        return
+      end
+
       local args = result[choice].args
       rt.dap.start(args)
     end


### PR DESCRIPTION
This prevents a .lua error when not selecting any value in the debuggables selection menu by e.g pressing Esc and closing the menu.