### PR TITLE
Handle multi-part inlay hint labels

### DIFF
--- a/lua/rust-tools/inlay_hints.lua
+++ b/lua/rust-tools/inlay_hints.lua
@@ -213,10 +213,18 @@ local function render_line(line, line_hints, bufnr)
   if not vim.tbl_isempty(other_hints) then
     virt_text = virt_text .. opts.other_hints_prefix
     for i, o_hint in ipairs(other_hints) do
-      if string.sub(o_hint.label, 1, 2) == ": " then
-        virt_text = virt_text .. o_hint.label:sub(3)
+      local label = o_hint.label
+      if type(label) == 'table' then
+        local parts = label
+        label = ''
+        for _, part in ipairs(parts) do
+          label = label .. part.value
+        end
+      end
+      if string.sub(label, 1, 2) == ": " then
+        virt_text = virt_text .. label:sub(3)
       else
-        virt_text = virt_text .. o_hint.label
+        virt_text = virt_text .. label
       end
       if i ~= #other_hints then
         virt_text = virt_text .. ", "


### PR DESCRIPTION
Currently the plugin shows an error message because it expects and assumes that `o_hint.label` is a string, but with these new multi-part inlay hints, they are an array of tables where the tables have a `value` attribute that contains the string of that part. I'm not sure about using the actual information that is provided by these multi-part hints (references to other items such as types, called "location links" I believe), but this patch at least retains the old behavior of just showing text.