### PR TITLE
fix(debuggables): fix choosing debuggable

### DIFF
--- a/lua/rust-tools/debuggables.lua
+++ b/lua/rust-tools/debuggables.lua
@@ -58,7 +58,7 @@ local function sanitize_results_for_debugging(result)
     return is_valid_test(value.args)
   end, result)
 
-  for i, value in ipairs(ret) do
+  for _, value in ipairs(ret) do
     rt.utils.sanitize_command_for_debugging(value.args.cargoArgs)
   end
 


### PR DESCRIPTION
Fixes #313 by filtering test compiler artifacts when debugging tests and bin compiler artifacts when debugging binary. Also adds check if multiple compiler artifacts are available as it is the case in running/debugging multiple test modules.