### PR TITLE
adding visibility of unittest binaries

### DIFF
--- a/lua/rust-tools/dap.lua
+++ b/lua/rust-tools/dap.lua
@@ -45,6 +45,7 @@ local function scheduled_error(err)
   end)
 end
 
+
 function M.start(args)
   if not pcall(require, "dap") then
     scheduled_error("nvim-dap not found.")
@@ -65,6 +66,7 @@ function M.start(args)
     "Compiling a debug build for debugging. This might take some time..."
   )
 
+  
   Job
     :new({
       command = "cargo",
@@ -96,8 +98,7 @@ function M.start(args)
               rt.utils.contains(artifact.target.crate_types, "bin")
             local is_build_script =
               rt.utils.contains(artifact.target.kind, "custom-build")
-            local is_test = rt.utils.contains(artifact.target.kind, "test")
-
+            local is_test = ((artifact.profile.test == true) and (artifact.executable ~= nil)) or rt.utils.contains(artifact.target.kind, "test")
             -- only add executable to the list if we want a binary debug and it is a binary
             -- or if we want a test debug and it is a test
             if


### PR DESCRIPTION
this fixes errors described by #324 and #322 

underlying issue was that unittests are described with `target.kind` == `"lib"` (or bin)  by `cargo test --mesage-format=json`. rust-tools expects that all tests would have `target.kind` == `"test"`. This prevented unittests from being visible. 

We make unittests visible by observing if `profile.test` is set in a cargo test json artifact