### PR TITLE
fix(#332): Don't render inlay hints for unloaded bufs

### DIFF
--- a/lua/rust-tools/inlay_hints.lua
+++ b/lua/rust-tools/inlay_hints.lua
@@ -160,7 +160,7 @@ function M.cache_render(self, bufnr)
             return
           end
 
-          if not vim.api.nvim_buf_is_valid(ctx.bufnr) then
+          if not vim.api.nvim_buf_is_loaded(ctx.bufnr) then
             self.cache[ctx.bufnr] = nil
             return
           end


### PR DESCRIPTION
A buffer might be unloaded even if it is valid, causing `nvim_buf_get_lines` to return empty array.

 Fix #332 