### PR TITLE
fix: error on shell == nil

### DIFF
--- a/lua/rust-tools/utils/utils.lua
+++ b/lua/rust-tools/utils/utils.lua
@@ -7,6 +7,7 @@ end
 
 function M.is_nushell()
     local shell = vim.loop.os_getenv("SHELL")
+    if shell == nil then return false end
     local nu = "nu"
     -- Check if $SHELL ends in "nu"
     return shell:sub(-string.len(nu)) == nu


### PR DESCRIPTION
Fixing error when "SHELL" is not defined in path.

![image](https://user-images.githubusercontent.com/65032978/221427171-ba61ff38-59d3-453e-9c24-c3991bcfd9ce.png)
Occured after running via :RustRunnables