### PR TITLE
feat: Make inlay_hints priority configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,9 @@ local opts = {
 
       -- The color of the hints
       highlight = "Comment",
+
+      -- priority of the virtual text
+      priority = 100,
     },
 
     -- options same as lsp hover / vim.lsp.util.open_floating_preview()

--- a/lua/rust-tools/config.lua
+++ b/lua/rust-tools/config.lua
@@ -56,6 +56,9 @@ local defaults = {
 
       -- The color of the hints
       highlight = "Comment",
+
+      -- priority of the virtual text
+      priority = 100,
     },
 
     -- options same as lsp hover / vim.lsp.util.open_floating_preview()

--- a/lua/rust-tools/inlay_hints.lua
+++ b/lua/rust-tools/inlay_hints.lua
@@ -251,6 +251,7 @@ local function render_line(line, line_hints, bufnr, max_line_len)
         { virt_text, opts.highlight },
       },
       hl_mode = "combine",
+      priority = opts.priority
     })
   end
 end


### PR DESCRIPTION
I'm using `gitsigns` with the `current_line_blame` configuration enabled. This basically shows the last change on the current line as virtual text.

For `rust` I would like to see the `inlay_hints` first and the blame information second. By default `gitsigns` uses a priority of `100`  (which I think is also the default in general, but couldn't find it in the docs).

This PR would make it possible to set the priority of the `inlay_hints` in the configuration of `rust-tools.nvim` and therefore create your own custom ordering (even if you have 15 more plugins for virtual text).

To my knowledge it doesn't change the default behaviour (which would put gitsigns blame in front)