### PR TITLE
add features  "choice module to use" and "support float notify window"

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,21 @@ local opts = {
       name = "rt_lldb",
     },
   },
+
+  -- choice module you use to speed up setuptime
+  open = {
+    crate_graph = true,
+    expand_macro = true,
+    external_docs = true,
+    debuggables = true,
+    hover_range = true,
+    workspace_refresh = true,
+    move_item = true,
+    standalone = true,
+    dap = true,
+    parent_module = true,
+    runnables = true,
+  },
 }
 
 require('rust-tools').setup(opts)

--- a/lua/rust-tools/config.lua
+++ b/lua/rust-tools/config.lua
@@ -8,7 +8,8 @@ _G.rust_tools_get_graphviz_backends = function()
 end
 
 local defaults = {
-  tools = { -- rust-tools options
+  tools = {
+    -- rust-tools options
 
     -- how to execute terminal commands
     -- options right now: termopen / quickfix
@@ -60,7 +61,6 @@ local defaults = {
 
     -- options same as lsp hover / vim.lsp.util.open_floating_preview()
     hover_actions = {
-
       -- the border that is used for the hover window
       -- see vim.api.nvim_open_win()
       border = {
@@ -180,12 +180,28 @@ local defaults = {
       name = "rt_lldb",
     },
   },
+
+  -- choice module you use
+  open = {
+    crate_graph = true,
+    expand_macro = true,
+    external_docs = true,
+    debuggables = true,
+    hover_range = true,
+    workspace_refresh = true,
+    move_item = true,
+    standalone = true,
+    dap = true,
+    parent_module = true,
+    runnables = true,
+  },
 }
 
 M.options = {
   tools = {},
   server = {},
   dap = {},
+  open = {},
 }
 
 function M.setup(options)

--- a/lua/rust-tools/init.lua
+++ b/lua/rust-tools/init.lua
@@ -29,6 +29,10 @@ local M = {
 }
 
 function M.setup(opts)
+  if opts.open == nil then
+    opts.open = {}
+  end
+
   local code_action_group = require("rust-tools.code_action_group")
   M.code_action_group = code_action_group
 
@@ -39,27 +43,37 @@ function M.setup(opts)
 
   local config = require("rust-tools.config")
   M.config = config
+  config.setup(opts)
 
-  local crate_graph = require("rust-tools.crate_graph")
-  M.crate_graph = crate_graph
+  local open = M.config.options.open
 
-  local rt_dap = require("rust-tools.dap")
-  M.dap = rt_dap
+  if open.crate_graph ~= false then
+    local crate_graph = require("rust-tools.crate_graph")
+    M.crate_graph = crate_graph
+  end
 
-  local debuggables = require("rust-tools.debuggables")
-  M.debuggables = debuggables
+  if open.debuggables ~= false then
+    local debuggables = require("rust-tools.debuggables")
+    M.debuggables = debuggables
+  end
 
-  local expand_macro = require("rust-tools.expand_macro")
-  M.expand_macro = expand_macro
+  if open.expand_macro ~= false then
+    local expand_macro = require("rust-tools.expand_macro")
+    M.expand_macro = expand_macro
+  end
 
-  local external_docs = require("rust-tools.external_docs")
-  M.external_docs = external_docs
+  if open.external_docs ~= false then
+    local external_docs = require("rust-tools.external_docs")
+    M.external_docs = external_docs
+  end
 
   local hover_actions = require("rust-tools.hover_actions")
   M.hover_actions = hover_actions
 
-  local hover_range = require("rust-tools.hover_range")
-  M.hover_range = hover_range
+  if open.hover_actions ~= false then
+    local hover_range = require("rust-tools.hover_range")
+    M.hover_range = hover_range
+  end
 
   local inlay = require("rust-tools.inlay_hints")
   local hints = inlay.new()
@@ -84,23 +98,31 @@ function M.setup(opts)
     end,
   }
 
-  local join_lines = require("rust-tools.join_lines")
-  M.join_lines = join_lines
+  if open.join_lines ~= false then
+    local join_lines = require("rust-tools.join_lines")
+    M.join_lines = join_lines
+  end
 
   local lsp = require("rust-tools.lsp")
   M.lsp = lsp
 
-  local move_item = require("rust-tools.move_item")
-  M.move_item = move_item
+  if open.move_item ~= false then
+    local move_item = require("rust-tools.move_item")
+    M.move_item = move_item
+  end
 
   local open_cargo_toml = require("rust-tools.open_cargo_toml")
   M.open_cargo_toml = open_cargo_toml
 
-  local parent_module = require("rust-tools.parent_module")
-  M.parent_module = parent_module
+  if open.parent_module ~= false then
+    local parent_module = require("rust-tools.parent_module")
+    M.parent_module = parent_module
+  end
 
-  local runnables = require("rust-tools.runnables")
-  M.runnables = runnables
+  if open.runnables ~= false then
+    local runnables = require("rust-tools.runnables")
+    M.runnables = runnables
+  end
 
   local server_status = require("rust-tools.server_status")
   M.server_status = server_status
@@ -108,21 +130,28 @@ function M.setup(opts)
   local ssr = require("rust-tools.ssr")
   M.ssr = ssr
 
-  local standalone = require("rust-tools.standalone")
-  M.standalone = standalone
+  if open.standalone ~= false then
+    local standalone = require("rust-tools.standalone")
+    M.standalone = standalone
+  end
 
-  local workspace_refresh = require("rust-tools.workspace_refresh")
-  M.workspace_refresh = workspace_refresh
+  if open.workspace_refresh ~= false then
+    local workspace_refresh = require("rust-tools.workspace_refresh")
+    M.workspace_refresh = workspace_refresh
+  end
 
   local utils = require("rust-tools.utils.utils")
   M.utils = utils
 
-  config.setup(opts)
   lsp.setup()
   commands.setup_lsp_commands()
 
-  if pcall(require, "dap") then
-    rt_dap.setup_adapter()
+  if opts.open.dap ~= false then
+    local rt_dap = require("rust-tools.dap")
+    M.dap = rt_dap
+    if pcall(require, "dap") then
+      rt_dap.setup_adapter()
+    end
   end
 end
 

--- a/lua/rust-tools/workspace_refresh.lua
+++ b/lua/rust-tools/workspace_refresh.lua
@@ -1,10 +1,14 @@
+local util = require("rust-tools.utils.utils")
 local M = {}
 
 local function handler(err)
   if err then
     error(tostring(err))
   end
-  vim.notify("Cargo workspace reloaded")
+  util.create_notify_floating_window(
+    { "Cargo Workspace reloaded" },
+    { width = 30 }
+  )
 end
 
 function M._reload_workspace_from_cargo_toml()
@@ -12,14 +16,20 @@ function M._reload_workspace_from_cargo_toml()
 
   for _, client in ipairs(clients) do
     if client.name == "rust_analyzer" then
-      vim.notify("Reloading Cargo Workspace")
+      util.create_notify_floating_window(
+        { "Reloading Cargo Workspace" },
+        { width = 30 }
+      )
       client.request("rust-analyzer/reloadWorkspace", nil, handler, 0)
     end
   end
 end
 
 function M.reload_workspace()
-  vim.notify("Reloading Cargo Workspace")
+  util.create_notify_floating_window({
+    "Reloading Cargo Workspace",
+    { width = 30 },
+  })
   vim.lsp.buf_request(0, "rust-analyzer/reloadWorkspace", nil, handler)
 end
 


### PR DESCRIPTION
# choice module

#364 

we want to disable some module that we will not use. 
So here is a simply solustion.
We can set options.open and open some module to use.
```
rt.setup({
 tools = {
    -- if you want disable hints use this config
    inlay_hints = {
      auto = false,
    }
  },

  open = {
    crate_graph = false,
    expand_macro = false,
    external_docs = true,
    debuggables = false,
    hover_range = false,
    workspace_refresh = true,
    move_item = false,
    standalone = false,
    dap = false,
    parent_module = false,
    runnables = false,
  },
})
```
# support float notify window
cargo workspace reloaded will trigger vim.notify() which give me a bad editing experience.
So I create  a float window to replace it.

![Peek 2023-05-14 13-08](https://github.com/simrat39/rust-tools.nvim/assets/81607010/f3954013-627d-4267-978d-1e387025959e)


