### PR TITLE
fix: set capability `augmentSyntaxTokens` to false

### DIFF
--- a/lua/rust-tools/lsp.lua
+++ b/lua/rust-tools/lsp.lua
@@ -133,6 +133,9 @@ local function setup_capabilities()
   -- snippets
   capabilities.textDocument.completion.completionItem.snippetSupport = true
 
+  -- output highlights for all semantic tokens
+  capabilities.textDocument.semanticTokens.augmentsSyntaxTokens = false
+
   -- send actions with hover request
   capabilities.experimental = {
     hoverActions = true,


### PR DESCRIPTION
Problem: rust-analyzer does not output semantic highlights for every token if the client registers the `augmentSyntaxTokens` capability, leading to keywords such as `dyn` and `as` being highlighted improperly. 

Solution: Explicitly disable the capabilty in `setup_capabilities()`.

Before:
![before](https://github.com/simrat39/rust-tools.nvim/assets/38540736/c34f9b77-729f-4570-95bb-7f2e93931799)

After:
![after](https://github.com/simrat39/rust-tools.nvim/assets/38540736/1f60e264-556d-4926-81b3-ca6390a3b5de)
