### PR TITLE
feat(opts): `executor` could be a string

### DIFF
--- a/lua/rust-tools/config.lua
+++ b/lua/rust-tools/config.lua
@@ -12,7 +12,7 @@ local defaults = {
 
     -- how to execute terminal commands
     -- options right now: termopen / quickfix / toggleterm / vimux
-    executor = require("rust-tools.executors").termopen,
+    executor = require("rust-tools.executors").termopen,  -- or "termopen"
 
     -- callback to execute once rust-analyzer is done initializing the workspace
     -- The callback receives one parameter indicating the `health` of the server: "ok" | "warning" | "error"

--- a/lua/rust-tools/runnables.lua
+++ b/lua/rust-tools/runnables.lua
@@ -45,10 +45,21 @@ function M.run_command(choice, result)
   end
 
   local opts = rt.config.options.tools
-
   local command, args, cwd = getCommand(choice, result)
+  local executor = opts.executor
 
-  opts.executor.execute_command(command, args, cwd)
+  if type(opts.executor) == "string" then
+    executor = require("rust-tools.executors")[opts.executor]
+  end
+
+  if executor then
+    executor.execute_command(command, args, cwd)
+  else
+    vim.notify(
+      "Invalid executor! Available: termopen / quickfix / toggleterm / vimux.",
+      vim.log.levels.ERROR
+    )
+  end
 end
 
 local function handler(_, result)


### PR DESCRIPTION
As a user, I prefer setting config without the need to know which I should require. I wonder if this would be considered as a breaking change.

### Example config
```lua
require("rust-tools").setup {
	tools = {
		executor = "toggleterm",
	}
}
```