### PR TITLE
Add syntax tree

### DIFF
--- a/doc/rust-tools.txt
+++ b/doc/rust-tools.txt
@@ -127,6 +127,9 @@ Note: Requires rust-analyzer version after 2021-08-02. Shows the type in visual 
 
 `lua   -- Command:   -- RustJoinLines     require'rust-tools'.join_lines.join_lines()`Structural Search Replace ~
 
+
+`lua   -- Command:   -- RustSyntaxTree    require'rust-tools'.syntax_tree.syntax_tree()`Show Syntax Tree ~
+
 >lua
       -- Command:
       -- RustSSR [query]

--- a/lua/rust-tools/init.lua
+++ b/lua/rust-tools/init.lua
@@ -52,6 +52,9 @@ function M.setup(opts)
   local expand_macro = require("rust-tools.expand_macro")
   M.expand_macro = expand_macro
 
+  local syntax_tree = require("rust-tools.syntax_tree")
+  M.syntax_tree = syntax_tree
+
   local external_docs = require("rust-tools.external_docs")
   M.external_docs = external_docs
 

--- a/lua/rust-tools/lsp.lua
+++ b/lua/rust-tools/lsp.lua
@@ -41,6 +41,7 @@ local function setup_commands()
       rt.debuggables.debuggables,
     },
     RustExpandMacro = { rt.expand_macro.expand_macro },
+    RustSyntaxTree = { rt.syntax_tree.syntax_tree },
     RustOpenExternalDocs = {
       rt.external_docs.open_external_docs,
     },

--- a/lua/rust-tools/syntax_tree.lua
+++ b/lua/rust-tools/syntax_tree.lua
@@ -1,0 +1,42 @@
+local rt = require("rust-tools")
+
+local M = {}
+
+local function get_params()
+  return vim.lsp.util.make_range_params()
+end
+
+local latest_buf_id = nil
+
+local function parse_lines(result)
+  local ret = {}
+
+  for line in string.gmatch(result, "([^\n]+)") do
+    table.insert(ret, line)
+  end
+
+  return ret
+end
+
+local function handler(_, result)
+  -- check if a buffer with the latest id is already open, if it is then
+  -- delete it and continue
+  rt.utils.delete_buf(latest_buf_id)
+
+  -- create a new buffer
+  latest_buf_id = vim.api.nvim_create_buf(false, true) -- not listed and scratch
+
+  -- split the window to create a new buffer and set it to our window
+  rt.utils.split(true, latest_buf_id)
+
+  vim.api.nvim_buf_set_name(latest_buf_id, "syntax.rust")
+  vim.api.nvim_buf_set_text(latest_buf_id, 0, 0, 0, 0, parse_lines(result))
+
+  rt.utils.resize(true, "-25")
+end
+
+function M.syntax_tree()
+  rt.utils.request(0, "rust-analyzer/syntaxTree", get_params(), handler)
+end
+
+return M


### PR DESCRIPTION
Add rust analyzers syntax tree (useful for mostly rust-analyzer developers)

Rust analyzer extension: https://github.com/rust-lang/rust-analyzer/blob/master/docs/dev/lsp-extensions.md#syntax-tree

![image](https://github.com/simrat39/rust-tools.nvim/assets/19900308/9e250877-7e91-46e9-8e8e-2f9c9e4e27c9)


_Not very experienced in writing nvim plugins so please point out if there is something wrong etc._