### PR TITLE
Fix `reload_workspace` sending RPC requests to unrelated LSP clients

### DIFF
--- a/lua/rust-tools/lsp.lua
+++ b/lua/rust-tools/lsp.lua
@@ -11,7 +11,7 @@ local function setup_autocmds()
   if rt.config.options.tools.reload_workspace_from_cargo_toml then
     vim.api.nvim_create_autocmd("BufWritePost", {
       pattern = "*/Cargo.toml",
-      callback = require('rust-tools.workspace_refresh')._reload_workspace_from_cargo_toml,
+      callback = require('rust-tools.workspace_refresh').reload_workspace,
       group = group,
     })
   end

--- a/lua/rust-tools/workspace_refresh.lua
+++ b/lua/rust-tools/workspace_refresh.lua
@@ -7,20 +7,12 @@ local function handler(err)
   vim.notify("Cargo workspace reloaded")
 end
 
-function M._reload_workspace_from_cargo_toml()
-  local clients = vim.lsp.get_active_clients()
-
-  for _, client in ipairs(clients) do
-    if client.name == "rust_analyzer" then
-      vim.notify("Reloading Cargo Workspace")
-      client.request("rust-analyzer/reloadWorkspace", nil, handler, 0)
-    end
-  end
-end
-
 function M.reload_workspace()
-  vim.notify("Reloading Cargo Workspace")
-  vim.lsp.buf_request(0, "rust-analyzer/reloadWorkspace", nil, handler)
+  local client = vim.lsp.get_active_clients({ name = "rust_analyzer" })
+  if #client ~= 0 then
+    vim.notify("Reloading Cargo Workspace")
+    client[1].request("rust-analyzer/reloadWorkspace", nil, handler, 0)
+  end
 end
 
 return M


### PR DESCRIPTION
Resolves #267.

- Removed [`_reload_workspace_from_cargo_toml`](https://github.com/simrat39/rust-tools.nvim/blob/0cc8adab23117783a0292a0c8a2fbed1005dc645/lua/rust-tools/workspace_refresh.lua#L10), replacing references with `reload_workspace`.

- Update [`reload_workspace`](https://github.com/simrat39/rust-tools.nvim/blob/0cc8adab23117783a0292a0c8a2fbed1005dc645/lua/rust-tools/workspace_refresh.lua#L21) to search through all clients by name for `"rust_analyzer"` to ensure RPC requests are only sent to the correct LSP client.