### PR TITLE
Fix non-existent property in `inlay-hints`

### DIFF
--- a/lua/rust-tools/inlay_hints.lua
+++ b/lua/rust-tools/inlay_hints.lua
@@ -16,7 +16,7 @@ end
 
 -- Disable hints and clear all cached buffers
 function M.disable(self)
-  self.disable = false
+  self.enabled = false
   M.disable_cache_autocmd()
 
   for k, _ in pairs(self.cache) do


### PR DESCRIPTION
`disabled` property does not exist in the `inlay_hints` module, probably `enabled` is meant?