### PR TITLE
Handle Invalid JSON in Cargo Output

### DIFF
--- a/lua/rust-tools/dap.lua
+++ b/lua/rust-tools/dap.lua
@@ -86,7 +86,10 @@ function M.start(args)
           local executables = {}
 
           for _, value in pairs(j:result()) do
-            local artifact = vim.fn.json_decode(value)
+            local ok, artifact = pcall(vim.fn.json_decode,value)
+            if not ok then
+               goto loop_end
+            end
 
             -- only process artifact if it's valid json object and it is a compiler artifact
             if


### PR DESCRIPTION
When running all tests of a file, the cargo command prints none JSON strings into stdout. Therefore, the debugging fails because the dap.lua file wasn't prepared for that. This commit makes the JSON parsing of the stdout output more robust by excepting none JSON formatted lines.