### PR TITLE
Allow override url opener

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,11 @@ local opts = {
     -- automatically call RustReloadWorkspace when writing to a Cargo.toml file.
     reload_workspace_from_cargo_toml = true,
 
+    -- function for opening external URLs
+    open_url = function(url)
+      vim.fn["netrw#BrowseX"](url, 0)
+    end,
+
     -- These apply to the default RustSetInlayHints command
     inlay_hints = {
       -- automatically set inlay hints (type hints)

--- a/lua/rust-tools/config.lua
+++ b/lua/rust-tools/config.lua
@@ -21,6 +21,11 @@ local defaults = {
     -- automatically call RustReloadWorkspace when writing to a Cargo.toml file.
     reload_workspace_from_cargo_toml = true,
 
+    -- function for opening external URLs
+    open_url = function(url)
+      vim.fn["netrw#BrowseX"](url, 0)
+    end,
+
     -- These apply to the default RustSetInlayHints command
     inlay_hints = {
       -- automatically set inlay hints (type hints)

--- a/lua/rust-tools/external_docs.lua
+++ b/lua/rust-tools/external_docs.lua
@@ -9,7 +9,7 @@ function M.open_external_docs()
     vim.lsp.util.make_position_params(),
     function(_, url)
       if url then
-        vim.fn["netrw#BrowseX"](url, 0)
+        rt.config.options.tools.open_url(url)
       end
     end
   )


### PR DESCRIPTION
Some, like me, who use [oil.nvim](https://github.com/stevearc/oil.nvim), [nvim-tree](https://github.com/nvim-tree/nvim-tree.lua) or similar, will get errors on `:RustOpenExternalDocs` with this:

```
Unknown function: netrw#BrowseX
```

This PR adds the capability to override url opener.

As a [lazy.nvim](https://github.com/folke/lazy.nvim) user, I use it like [this](https://github.com/olidacombe/dotfiles/blob/91fd998df09a7c7468f24f43b95b5b8c6db3b853/dot_config/nvim/after/plugin/rust-tools.lua#L75-L77).