### PR TITLE
Update dap.lua with startup error Fix

### DIFF
--- a/lua/rust-tools/dap.lua
+++ b/lua/rust-tools/dap.lua
@@ -90,29 +90,25 @@ function M.start(args)
 
             -- only process artifact if it's valid json object and it is a compiler artifact
             if
-              type(artifact) ~= "table"
-              or artifact.reason ~= "compiler-artifact"
+              type(artifact) == "table"
+              or artifact.reason == "compiler-artifact"
             then
-              goto loop_end
+              local is_binary =
+                rt.utils.contains(artifact.target.crate_types, "bin")
+              local is_build_script =
+                rt.utils.contains(artifact.target.kind, "custom-build")
+              local is_test = (
+                (artifact.profile.test == true) and (artifact.executable ~= nil)
+              ) or rt.utils.contains(artifact.target.kind, "test")
+              -- only add executable to the list if we want a binary debug and it is a binary
+              -- or if we want a test debug and it is a test
+              if
+                (cargo_args[1] == "build" and is_binary and not is_build_script)
+                or (cargo_args[1] == "test" and is_test)
+              then
+                table.insert(executables, artifact.executable)
+              end
             end
-
-            local is_binary =
-              rt.utils.contains(artifact.target.crate_types, "bin")
-            local is_build_script =
-              rt.utils.contains(artifact.target.kind, "custom-build")
-            local is_test = (
-              (artifact.profile.test == true) and (artifact.executable ~= nil)
-            ) or rt.utils.contains(artifact.target.kind, "test")
-            -- only add executable to the list if we want a binary debug and it is a binary
-            -- or if we want a test debug and it is a test
-            if
-              (cargo_args[1] == "build" and is_binary and not is_build_script)
-              or (cargo_args[1] == "test" and is_test)
-            then
-              table.insert(executables, artifact.executable)
-            end
-
-            ::loop_end::
           end
 
           -- only 1 executable is allowed for debugging - error out if zero or many were found

--- a/lua/rust-tools/dap.lua
+++ b/lua/rust-tools/dap.lua
@@ -91,7 +91,7 @@ function M.start(args)
             -- only process artifact if it's valid json object and it is a compiler artifact
             if
               type(artifact) == "table"
-              or artifact.reason == "compiler-artifact"
+              and artifact.reason == "compiler-artifact"
             then
               local is_binary =
                 rt.utils.contains(artifact.target.crate_types, "bin")


### PR DESCRIPTION
Fix error from startup -
E5113: Error while calling lua chunk: .../nvim/site/pack/git-plugins/start/rust-tools.nvim/lua/rust-tools/dap.lua:96: '=' expected near 'loop_end' stack traceback:
        [C]: in function 'error'
        ?: in function <?:15>
        [C]: in function 'require'
        ...lugins/start/rust-tools.nvim/lua/rust-tools/init.lua:46: in function 'setup'

Inverted negative check and removed goto