### PR TITLE
Correctly reference utils module

### DIFF
--- a/lua/rust-tools/commands.lua
+++ b/lua/rust-tools/commands.lua
@@ -1,4 +1,5 @@
 local rt = require("rust-tools")
+local rt_utils = require("rust-tools.utils.utils")
 
 local M = {}
 
@@ -17,7 +18,7 @@ function M.setup_lsp_commands()
   end
 
   vim.lsp.commands["rust-analyzer.debugSingle"] = function(command)
-    rt.utils.sanitize_command_for_debugging(command.arguments[1].args.cargoArgs)
+    rt_utils.sanitize_command_for_debugging(command.arguments[1].args.cargoArgs)
     rt.dap.start(command.arguments[1].args)
   end
 end

--- a/lua/rust-tools/crate_graph.lua
+++ b/lua/rust-tools/crate_graph.lua
@@ -1,4 +1,5 @@
 local rt = require("rust-tools")
+local rt_utils = require("rust-tools.utils.utils")
 
 local M = {}
 
@@ -24,7 +25,7 @@ local function handler_factory(backend, output, pipe)
 
     -- Validating backend
     if
-      not rt.utils.contains(
+      not rt_utils.contains(
         rt.config.options.tools.crate_graph.enabled_graphviz_backends,
         backend
       )
@@ -56,7 +57,7 @@ local function handler_factory(backend, output, pipe)
 end
 
 function M.view_crate_graph(backend, output, pipe)
-  rt.utils.request(
+  rt_utils.request(
     0,
     "rust-analyzer/viewCrateGraph",
     get_opts(),

--- a/lua/rust-tools/dap.lua
+++ b/lua/rust-tools/dap.lua
@@ -1,4 +1,5 @@
 local rt = require("rust-tools")
+local rt_utils = require("rust-tools.utils.utils")
 
 local M = {}
 
@@ -30,12 +31,12 @@ local function get_cargo_args_from_runnables_args(runnable_args)
   local cargo_args = runnable_args.cargoArgs
 
   local message_json = "--message-format=json"
-  if not rt.utils.contains(cargo_args, message_json) then
+  if not rt_utils.contains(cargo_args, message_json) then
     table.insert(cargo_args, message_json)
   end
 
   for _, value in ipairs(runnable_args.cargoExtraArgs) do
-    if not rt.utils.contains(cargo_args, value) then
+    if not rt_utils.contains(cargo_args, value) then
       table.insert(cargo_args, value)
     end
   end
@@ -97,12 +98,12 @@ function M.start(args)
             end
 
             local is_binary =
-              rt.utils.contains(artifact.target.crate_types, "bin")
+              rt_utils.contains(artifact.target.crate_types, "bin")
             local is_build_script =
-              rt.utils.contains(artifact.target.kind, "custom-build")
+              rt_utils.contains(artifact.target.kind, "custom-build")
             local is_test = (
               (artifact.profile.test == true) and (artifact.executable ~= nil)
-            ) or rt.utils.contains(artifact.target.kind, "test")
+            ) or rt_utils.contains(artifact.target.kind, "test")
             -- only add executable to the list if we want a binary debug and it is a binary
             -- or if we want a test debug and it is a test
             if

--- a/lua/rust-tools/debuggables.lua
+++ b/lua/rust-tools/debuggables.lua
@@ -1,4 +1,5 @@
 local rt = require("rust-tools")
+local rt_utils = require("rust-tools.utils.utils")
 
 local M = {}
 
@@ -59,7 +60,7 @@ local function sanitize_results_for_debugging(result)
   end, result)
 
   for _, value in ipairs(ret) do
-    rt.utils.sanitize_command_for_debugging(value.args.cargoArgs)
+    rt_utils.sanitize_command_for_debugging(value.args.cargoArgs)
   end
 
   return ret
@@ -93,7 +94,7 @@ end
 -- which is used to check whether we want to use telescope or the vanilla vim
 -- way for input
 function M.debuggables()
-  rt.utils.request(0, "experimental/runnables", get_params(), handler)
+  rt_utils.request(0, "experimental/runnables", get_params(), handler)
 end
 
 return M

--- a/lua/rust-tools/expand_macro.lua
+++ b/lua/rust-tools/expand_macro.lua
@@ -1,4 +1,4 @@
-local rt = require("rust-tools")
+local rt_utils = require("rust-tools.utils.utils")
 
 local M = {}
 
@@ -44,13 +44,13 @@ local function handler(_, result)
 
   -- check if a buffer with the latest id is already open, if it is then
   -- delete it and continue
-  rt.utils.delete_buf(latest_buf_id)
+  rt_utils.delete_buf(latest_buf_id)
 
   -- create a new buffer
   latest_buf_id = vim.api.nvim_create_buf(false, true) -- not listed and scratch
 
   -- split the window to create a new buffer and set it to our window
-  rt.utils.split(true, latest_buf_id)
+  rt_utils.split(true, latest_buf_id)
 
   -- set filetpe to rust for syntax highlighting
   vim.api.nvim_buf_set_option(latest_buf_id, "filetype", "rust")
@@ -58,12 +58,12 @@ local function handler(_, result)
   vim.api.nvim_buf_set_lines(latest_buf_id, 0, 0, false, parse_lines(result))
 
   -- make the new buffer smaller
-  rt.utils.resize(true, "-25")
+  rt_utils.resize(true, "-25")
 end
 
 -- Sends the request to rust-analyzer to get cargo.tomls location and open it
 function M.expand_macro()
-  rt.utils.request(0, "rust-analyzer/expandMacro", get_params(), handler)
+  rt_utils.request(0, "rust-analyzer/expandMacro", get_params(), handler)
 end
 
 return M

--- a/lua/rust-tools/external_docs.lua
+++ b/lua/rust-tools/external_docs.lua
@@ -1,9 +1,9 @@
-local rt = require("rust-tools")
+local rt_utils = require("rust-tools.utils.utils")
 
 local M = {}
 
 function M.open_external_docs()
-  rt.utils.request(
+  rt_utils.request(
     0,
     "experimental/externalDocs",
     vim.lsp.util.make_position_params(),

--- a/lua/rust-tools/hover_actions.lua
+++ b/lua/rust-tools/hover_actions.lua
@@ -1,4 +1,5 @@
 local rt = require("rust-tools")
+local rt_utils = require("rust-tools.utils.utils")
 local util = vim.lsp.util
 
 local M = {}
@@ -10,7 +11,7 @@ end
 M._state = { winnr = nil, commands = nil }
 
 local function close_hover()
-  rt.utils.close_win(M._state.winnr)
+  rt_utils.close_win(M._state.winnr)
 end
 
 -- run the command under the cursor, if the thing under the cursor is not the
@@ -134,7 +135,7 @@ end
 
 -- Sends the request to rust-analyzer to get hover actions and handle it
 function M.hover_actions()
-  rt.utils.request(0, "textDocument/hover", get_params(), M.handler)
+  rt_utils.request(0, "textDocument/hover", get_params(), M.handler)
 end
 
 return M

--- a/lua/rust-tools/hover_range.lua
+++ b/lua/rust-tools/hover_range.lua
@@ -1,4 +1,4 @@
-local rt = require("rust-tools")
+local rt_utils = require("rust-tools.utils.utils")
 
 local M = {}
 
@@ -23,7 +23,7 @@ local function get_opts()
 end
 
 function M.hover_range()
-  rt.utils.request(0, "textDocument/hover", get_opts())
+  rt_utils.request(0, "textDocument/hover", get_opts())
 end
 
 return M

--- a/lua/rust-tools/inlay_hints.lua
+++ b/lua/rust-tools/inlay_hints.lua
@@ -1,4 +1,5 @@
 local rt = require("rust-tools")
+local rt_utils = require("rust-tools.utils.utils")
 
 local M = {}
 
@@ -151,7 +152,7 @@ function M.cache_render(self, bufnr)
   local buffer = bufnr or vim.api.nvim_get_current_buf()
 
   for _, v in pairs(vim.lsp.get_active_clients({ bufnr = buffer })) do
-    if rt.utils.is_ra_server(v) then
+    if rt_utils.is_ra_server(v) then
       v.request(
         "textDocument/inlayHint",
         get_params(v, buffer),

--- a/lua/rust-tools/join_lines.lua
+++ b/lua/rust-tools/join_lines.lua
@@ -1,4 +1,4 @@
-local rt = require("rust-tools")
+local rt_utils = require("rust-tools.utils.utils")
 
 local M = {}
 
@@ -23,7 +23,7 @@ end
 -- Sends the request to rust-analyzer to get the TextEdits to join the lines
 -- under the cursor and applies them
 function M.join_lines()
-  rt.utils.request(0, "experimental/joinLines", get_params(), handler)
+  rt_utils.request(0, "experimental/joinLines", get_params(), handler)
 end
 
 return M

--- a/lua/rust-tools/lsp.lua
+++ b/lua/rust-tools/lsp.lua
@@ -1,4 +1,5 @@
 local rt = require("rust-tools")
+local rt_utils = require("rust-tools.utils.utils")
 local lspconfig = require("lspconfig")
 local lspconfig_utils = require("lspconfig.util")
 local server_status = require("rust-tools.server_status")
@@ -103,7 +104,7 @@ local function setup_handlers()
     )
   end
 
-  custom_handlers["experimental/serverStatus"] = rt.utils.mk_handler(
+  custom_handlers["experimental/serverStatus"] = rt_utils.mk_handler(
     server_status.handler
   )
 
@@ -119,7 +120,7 @@ local function setup_on_init()
   local old_on_init = lsp_opts.on_init
 
   lsp_opts.on_init = function(...)
-    rt.utils.override_apply_text_edits()
+    rt_utils.override_apply_text_edits()
     if old_on_init ~= nil then
       old_on_init(...)
     end
@@ -213,7 +214,7 @@ function M.start_standalone_if_required()
 
   if
     lsp_opts.standalone
-    and rt.utils.is_bufnr_rust(current_buf)
+    and rt_utils.is_bufnr_rust(current_buf)
     and (get_root_dir() == nil)
   then
     require("rust-tools.standalone").start_standalone_client()

--- a/lua/rust-tools/move_item.lua
+++ b/lua/rust-tools/move_item.lua
@@ -1,4 +1,4 @@
-local rt = require("rust-tools")
+local rt_utils = require("rust-tools.utils.utils")
 
 local M = {}
 
@@ -15,7 +15,7 @@ local function handler(_, result, ctx)
   if result == nil then
     return
   end
-  rt.utils.snippet_text_edits_to_text_edits(result)
+  rt_utils.snippet_text_edits_to_text_edits(result)
   vim.lsp.util.apply_text_edits(
     result,
     ctx.bufnr,
@@ -25,7 +25,7 @@ end
 
 -- Sends the request to rust-analyzer to move the item and handle the response
 function M.move_item(up)
-  rt.utils.request(0, "experimental/moveItem", get_params(up or false), handler)
+  rt_utils.request(0, "experimental/moveItem", get_params(up or false), handler)
 end
 
 return M

--- a/lua/rust-tools/open_cargo_toml.lua
+++ b/lua/rust-tools/open_cargo_toml.lua
@@ -1,4 +1,4 @@
-local rt = require("rust-tools")
+local rt_utils = require("rust-tools.utils.utils")
 
 local M = {}
 
@@ -19,7 +19,7 @@ end
 
 -- Sends the request to rust-analyzer to get cargo.tomls location and open it
 function M.open_cargo_toml()
-  rt.utils.request(0, "experimental/openCargoToml", get_params(), handler)
+  rt_utils.request(0, "experimental/openCargoToml", get_params(), handler)
 end
 
 return M

--- a/lua/rust-tools/parent_module.lua
+++ b/lua/rust-tools/parent_module.lua
@@ -1,4 +1,4 @@
-local rt = require("rust-tools")
+local rt_utils = require("rust-tools.utils.utils")
 
 local M = {}
 
@@ -24,7 +24,7 @@ end
 
 -- Sends the request to rust-analyzer to get the parent modules location and open it
 function M.parent_module()
-  rt.utils.request(0, "experimental/parentModule", get_params(), handler)
+  rt_utils.request(0, "experimental/parentModule", get_params(), handler)
 end
 
 return M

--- a/lua/rust-tools/runnables.lua
+++ b/lua/rust-tools/runnables.lua
@@ -1,4 +1,5 @@
 local rt = require("rust-tools")
+local rt_utils = require("rust-tools.utils.utils")
 
 local M = {}
 
@@ -69,7 +70,7 @@ end
 -- which is used to check whether we want to use telescope or the vanilla vim
 -- way for input
 function M.runnables()
-  rt.utils.request(0, "experimental/runnables", get_params(), handler)
+  rt_utils.request(0, "experimental/runnables", get_params(), handler)
 end
 
 return M

--- a/lua/rust-tools/ssr.lua
+++ b/lua/rust-tools/ssr.lua
@@ -1,4 +1,4 @@
-local rt = require("rust-tools")
+local rt_utils = require("rust-tools.utils.utils")
 
 local M = {}
 
@@ -27,7 +27,7 @@ function M.ssr(query)
   end
 
   if query then
-    rt.utils.request(0, "experimental/ssr", get_opts(query), handler)
+    rt_utils.request(0, "experimental/ssr", get_opts(query), handler)
   end
 end
 


### PR DESCRIPTION
Hi! I noticed that the `utils` module (the `utils/utils.lua` file) was being read as `nil`. Lua seems to do this weird thing of silently exiting when calling `.something` on a `nil` value, so the DAP setup was not working correctly.

This change fixes this issue by importing the `utils` module like so and adjusting the references to match:
```
local rt_utils = require('rust-tools.utils.utils')
...
rt_utils.compare(...)
```

See the photo for evidence that a `nil` value was being read. On the left is the code I added to log the issue, on the bottom right is the log's output.
![screenshot-20231220-210426](https://github.com/simrat39/rust-tools.nvim/assets/91363480/642bb40a-1561-4754-8ae0-c6d88a2e4021)
